### PR TITLE
Add some type mappings

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -254,7 +254,9 @@ module RbsRails
         case t
         when :integer
           Integer.name
-        when :string, :text, :uuid
+        when :float
+          Float.name
+        when :string, :text, :uuid, :binary
           String.name
         when :datetime
           # TODO


### PR DESCRIPTION
This adds some type mappings that needed for real Rails apps.

* `:float` => `"Float"`
* `:binary` => `"String"`