### PR TITLE
add time type to sql_type_to_class

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -270,6 +270,8 @@ module RbsRails
           # TODO
           # Date.name
           'untyped'
+        when :time
+          Time.name
         else
           raise "unexpected: #{t.inspect}"
         end


### PR DESCRIPTION
Add time type.

When I tried this in a Rails project that has a column of type Time, it raises `unexpected: :time`, so I'll add the type.
But, since the Time class in Ruby and the Time type in DB are different, I'm wondering if the type name should be `Time.name`.
