### PR TITLE
Add type IPAddr (inet)

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -272,6 +272,8 @@ module RbsRails
           'untyped'
         when :time
           Time.name
+        when :inet
+          "IPAddr"
         else
           raise "unexpected: #{t.inspect}"
         end


### PR DESCRIPTION
Though it is a PostgreSQL-dependent feature, `inet` was needed to type Mastodon.
https://github.com/tootsuite/mastodon
https://github.com/tootsuite/mastodon/blob/ce9ae9aa50/db/schema.rb#L705