### PR TITLE
Generate additional signatures for auto-generated AR methods

### DIFF
--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -53,6 +53,8 @@ class RbsRails::ActiveRecord::Generator
 
   def sql_type_to_class: (untyped t) -> untyped
 
+  def optional: (String) -> String
+
   attr_reader klass: singleton(ActiveRecord::Base)
 
   attr_reader mode: (:extension | :class)


### PR DESCRIPTION
AR automatically creates some additional methods which correspond to DB columns.

* `ActiveRecord::Base` includes [`ActiveModel::Dirty`](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html) 
  * We can use some auto-generated methods like `foo_changed?` or `foo_will_change!` for column `foo`
* `bar?` is also generated for `:boolean` column `bar`

It would be an advantage to developers if RBS Rails generated signatures for those auto-generated methods.

I tried `steep check` with [newly-generated signatures](https://github.com/tadd/mastodon/commit/e9e92889a15e3bce05775ff3bab914240139632c). It passed without syntactic errors.