### PR TITLE
Add PG module

### DIFF
--- a/assets/sig/pg.rbs
+++ b/assets/sig/pg.rbs
@@ -1,0 +1,2 @@
+module PG
+end


### PR DESCRIPTION
To avoid the following error

```
$ bundle exec rake rbs_validate

(snip)

Validating class/module definition: `::PG::Connection`...
/path/to/rbs-0.12.2/lib/rbs/errors.rb:122:in `check!': assets/sig/generated/activerecord.rbs:9806:0...9807:3: Could not find ::PG (RBS::NoTypeFoundError)
        from /path/to/rbs-0.12.2/lib/rbs/definition_builder.rb:397:in `block in ensure_namespace!'
        from /path/to/rbs-0.12.2/lib/rbs/namespace.rb:102:in `ascend'
        from /path/to/rbs-0.12.2/lib/rbs/definition_builder.rb:395:in `ensure_namespace!'
        from /path/to/rbs-0.12.2/lib/rbs/definition_builder.rb:405:in `block in build_instance'
        from /path/to/rbs-0.12.2/lib/rbs/definition_builder.rb:1048:in `try_cache'
        from /path/to/rbs-0.12.2/lib/rbs/definition_builder.rb:403:in `build_instance'
        from /path/to/rbs-0.12.2/lib/rbs/cli.rb:399:in `block in run_validate'
        from /path/to/rbs-0.12.2/lib/rbs/cli.rb:397:in `each_key'
        from /path/to/rbs-0.12.2/lib/rbs/cli.rb:397:in `run_validate'
        from /path/to/rbs-0.12.2/lib/rbs/cli.rb:97:in `run'
        from /path/to/rbs-0.12.2/exe/rbs:7:in `<top (required)>'
        from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `load'
        from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `<main>'
rake aborted!
```