### PR TITLE
Add decimal column support

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -268,6 +268,8 @@ module RbsRails
           Integer.name
         when :float
           Float.name
+        when :decimal
+          BigDecimal.name
         when :string, :text, :citext, :uuid, :binary
           String.name
         when :datetime


### PR DESCRIPTION
Add decimal column support as BigDecimal in this PR. BigDecimal is not built-in, but it is required in ActiveRecord.

When I ran [this rake task](https://github.com/pocke/rbs_rails#for-active-record-models) in my rails app I got the following error.
```
/myapp # bundle exec rails generate_rbs_for_model -t
** Invoke generate_rbs_for_model (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute generate_rbs_for_model
rails aborted!
unexpected: :decimal
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:290:in `sql_type_to_class'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:241:in `block in columns'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:240:in `map'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:240:in `columns'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:25:in `klass_decl'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:14:in `generate'
/usr/local/bundle/gems/rbs_rails-0.3.0/lib/rbs_rails/active_record.rb:4:in `class_to_rbs'
/myapp/rakefile:33:in `block (3 levels) in <top (required)>'
/myapp/rakefile:27:in `each'
/myapp/rakefile:27:in `block (2 levels) in <top (required)>'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:281:in `block in execute'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:281:in `each'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:281:in `execute'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:219:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `synchronize'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:199:in `invoke_with_call_chain'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/task.rb:188:in `invoke'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:160:in `invoke_task'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `each'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:116:in `block in top_level'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:125:in `run_with_threads'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:110:in `top_level'
/usr/local/bundle/gems/railties-6.0.3.3/lib/rails/commands/rake/rake_command.rb:23:in `block in perform'
/usr/local/lib/ruby/gems/2.7.0/gems/rake-13.0.1/lib/rake/application.rb:186:in `standard_exception_handling'
/usr/local/bundle/gems/railties-6.0.3.3/lib/rails/commands/rake/rake_command.rb:20:in `perform'
/usr/local/bundle/gems/railties-6.0.3.3/lib/rails/command.rb:48:in `invoke'
/usr/local/bundle/gems/railties-6.0.3.3/lib/rails/commands.rb:18:in `<top (required)>'
bin/rails:4:in `require'
bin/rails:4:in `<main>'
Tasks: TOP => generate_rbs_for_model
```

With this fix, the rake task completed successfully.