### PR TITLE
Re generate rbs

### DIFF
--- a/assets/sig/generated/actionpack.rbs
+++ b/assets/sig/generated/actionpack.rbs
@@ -4936,7 +4936,7 @@ module ActionDispatch
 
       HTTP_HEADER: untyped
 
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       def self.from_hash: (untyped hash) -> untyped
 
@@ -5063,7 +5063,7 @@ end
 
 module Mime
   class Mimes
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     def initialize: () -> untyped
 
@@ -6371,7 +6371,7 @@ module ActionDispatch
         # :nodoc:
         # :nodoc:
         # :nodoc:
-        include Enumerable[untyped, untyped]
+        include Enumerable[untyped]
 
         attr_accessor left: untyped
 
@@ -6879,7 +6879,7 @@ module ActionDispatch
       # The Routing table. Contains all routes for a system. Routes can be
       # added to the table by calling Routes#add_route.
       # :nodoc:
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       attr_reader routes: untyped
 
@@ -7338,7 +7338,7 @@ module ActionDispatch
 
     class CookieJar
       # nodoc:
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       # nodoc:
       include ChainedCookieJars
@@ -7715,7 +7715,7 @@ module ActionDispatch
     end
 
     class FlashHash
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       def self.from_session_value: (untyped value) -> untyped
 
@@ -8310,7 +8310,7 @@ module ActionDispatch
       def call: (untyped env) -> untyped
     end
 
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     attr_accessor middlewares: untyped
 
@@ -9909,7 +9909,7 @@ module ActionDispatch
 
         def []: (untyped key) -> untyped
 
-        include Enumerable[untyped, untyped]
+        include Enumerable[untyped]
 
         def each: () { (untyped) -> untyped } -> untyped
 
@@ -10228,7 +10228,7 @@ module ActionDispatch
       # maintains an anonymous module that can be used to install helpers for the
       # named routes.
       class NamedRouteCollection
-        include Enumerable[untyped, untyped]
+        include Enumerable[untyped]
 
         attr_reader routes: untyped
 

--- a/assets/sig/generated/actionview.rbs
+++ b/assets/sig/generated/actionview.rbs
@@ -8954,7 +8954,7 @@ module ActionView
     #
     # A +LookupContext+ will use a +PathSet+ to store the paths in its context.
     # nodoc:
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     attr_reader paths: untyped
 

--- a/assets/sig/generated/activemodel.rbs
+++ b/assets/sig/generated/activemodel.rbs
@@ -1305,7 +1305,7 @@ module ActiveModel
   #   person.errors.full_messages # => ["name cannot be nil"]
   #   # etc..
   class Errors
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     CALLBACKS_OPTIONS: ::Array[untyped]
 

--- a/assets/sig/generated/activerecord.rbs
+++ b/assets/sig/generated/activerecord.rbs
@@ -1879,7 +1879,7 @@ module ActiveRecord
         # operations (for example a has_and_belongs_to_many JoinAssociation would result in
         # two; one for the join table and one for the target table).
         # :nodoc:
-        include Enumerable[untyped, untyped]
+        include Enumerable[untyped]
 
         # The Active Record class which this join part is associated 'about'; for a JoinBase
         # this is the actual base model, for a JoinAssociation this is the target model of the
@@ -11613,7 +11613,7 @@ module ActiveRecord
   module ConnectionAdapters
     class StatementPool
       # :nodoc:
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       DEFAULT_STATEMENT_LIMIT: ::Integer
 
@@ -12836,7 +12836,7 @@ module ActiveRecord
   class FixtureSet
     class File
       # :nodoc:
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       #
       # Open a fixture file named +file+.  When called with a block, the block
@@ -13465,7 +13465,7 @@ module ActiveRecord
 
   class Fixture
     # nodoc:
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     class FixtureError < StandardError
     end
@@ -17286,7 +17286,7 @@ end
 module ActiveRecord
   module Batches
     class BatchEnumerator
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       def initialize: (relation: untyped relation, ?of: ::Integer of, ?start: untyped? start, ?finish: untyped? finish) -> untyped
 
@@ -19192,7 +19192,7 @@ module ActiveRecord
 
     VALUE_METHODS: untyped
 
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     include FinderMethods
 
@@ -19693,7 +19693,7 @@ module ActiveRecord
   #     puts row['title'] + " " + row['body']
   #   end
   class Result
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     attr_reader columns: untyped
 
@@ -22777,7 +22777,7 @@ module Arel
     class Node
       include Arel::FactoryMethods
 
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       # #
       # Factory method to create a Nodes::Not node that has the recipient of

--- a/assets/sig/generated/activesupport.rbs
+++ b/assets/sig/generated/activesupport.rbs
@@ -1383,7 +1383,7 @@ module ActiveSupport
 
     class CallbackChain
       # nodoc:#
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       attr_reader name: untyped
 
@@ -2985,7 +2985,7 @@ module Digest
   end
 end
 
-module Enumerable[unchecked out Elem, out Return]
+module Enumerable[unchecked out Elem]
   INDEX_WITH_DEFAULT: untyped
 
   # We can't use Refinements here because Refinements with Module which will be prepended
@@ -4843,7 +4843,7 @@ class Regexp
   def as_json: (?untyped? options) -> untyped
 end
 
-module Enumerable[unchecked out Elem, out Return]
+module Enumerable[unchecked out Elem]
   def as_json: (?untyped? options) -> untyped
 end
 
@@ -6505,7 +6505,7 @@ module ActiveSupport
     # This is handled by walking back up the watch stack and adding the constants
     # found by child.rb to the list of original constants in parent.rb.
     class WatchStack
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       attr_reader watching: untyped
 
@@ -7108,7 +7108,7 @@ module ActiveSupport
     class DescendantsArray
       # DescendantsArray is an array that contains weak references to classes.
       # :nodoc:
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       def initialize: () -> untyped
 

--- a/assets/sig/generated/railties.rbs
+++ b/assets/sig/generated/railties.rbs
@@ -623,7 +623,7 @@ end
 
 module Rails
   module Autoloaders
-    include Enumerable[untyped, untyped]
+    include Enumerable[untyped]
 
     def self.main: () -> untyped
 
@@ -1504,7 +1504,7 @@ end
 module Rails
   class Engine < Railtie
     class Railties
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       attr_reader _all: untyped
 
@@ -4065,7 +4065,7 @@ module Rails
     end
 
     class Path
-      include Enumerable[untyped, untyped]
+      include Enumerable[untyped]
 
       attr_accessor glob: untyped
 

--- a/bin/add-type-params.rb
+++ b/bin/add-type-params.rb
@@ -4,7 +4,7 @@ require 'bundler/inline'
 
 gemfile do
   source 'https://rubygems.org'
-  gem 'rbs', '>= 0.16'
+  gem 'rbs', '>= 0.17'
 end
 
 require 'rbs'

--- a/bin/generate_rbs_from_rails_source_code.rb
+++ b/bin/generate_rbs_from_rails_source_code.rb
@@ -166,7 +166,7 @@ def patch!(name, rbs)
   end
 end
 
-def generate!(rails_code_dir, name)
+def generate1!(rails_code_dir, name)
   files = Pathname(rails_code_dir).join(name, 'lib').glob('**/*.rb').map(&:to_s)
   generated_rbs_path = SIG_DIR.join("#{name}.rbs")
 
@@ -176,6 +176,11 @@ def generate!(rails_code_dir, name)
   patch! name, rbs
   generated_rbs_path.write(rbs)
 
+end
+
+def generate2!(rails_code_dir, name)
+  generated_rbs_path = SIG_DIR.join("#{name}.rbs")
+
   rbs = sh! 'ruby', bin('add-type-params.rb'), generated_rbs_path.to_s
   generated_rbs_path.write(rbs)
 
@@ -184,11 +189,12 @@ end
 
 def main(rails_code_dir, name)
   if name == 'all'
-    %w[actionpack activejob railties activemodel activesupport actionview activerecord].each do |n|
-      generate!(rails_code_dir, n)
-    end
+    gems = %w[activesupport actionpack activejob activemodel actionview activerecord railties]
+    gems.each { |n| generate1!(rails_code_dir, n) }
+    gems.each { |n| generate2!(rails_code_dir, n) }
   else
-    generate!(rails_code_dir, name)
+    generate1!(rails_code_dir, name)
+    generate2!(rails_code_dir, name)
   end
 end
 

--- a/bin/postprocess.rb
+++ b/bin/postprocess.rb
@@ -6,7 +6,7 @@ require 'bundler/inline'
 
 gemfile do
   source 'https://rubygems.org'
-  gem 'rbs', '>= 0.16'
+  gem 'rbs', '>= 0.17'
 end
 
 require 'rbs'

--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -35,7 +35,7 @@ module RbsRails
         <<~RBS
           class #{relation_class_name} < ActiveRecord::Relation
             include _ActiveRecord_Relation[#{klass.name}]
-            include Enumerable[#{klass.name}, self]
+            include Enumerable[#{klass.name}]
           #{enum_scope_methods(singleton: false).indent(2)}
           #{scopes(singleton: false).indent(2)}
           end

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rbs_rails (0.3.0)
+    rbs_rails (0.4.0)
       parser
 
 GEM


### PR DESCRIPTION
This pull request re-generates RBS files for RBS v0.17. Because it drops Enumerable `Return` type parameter.

And this pull request also updates the tools to generate RBS.

fixes #62 