### PR TITLE
Add rbs gem to runtime dependency

### DIFF
--- a/rbs_rails.gemspec
+++ b/rbs_rails.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency 'parser'
+  spec.add_runtime_dependency 'rbs', '>= 0.17'
 end


### PR DESCRIPTION
RBS Rails actually doesn't load RBS gem on runtime,
but the generated RBS files depend on RBS gem version.
So I think we need to specify RBS gem version in gemspec.