### PR TITLE
Add RbsRails::RakeTask to expose RBS generators to Rails application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@
 /spec/reports/
 /tmp/
 /Gemfile.lock
-/test/sig
+/test/app/sig/rbs_rails
+/test/app/sig/app
+/test/app/sig/path_helpers.rbs

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ RBS files generator for Ruby on Rails.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rbs_rails'
+gem 'rbs_rails', require: false
 ```
 
 And then execute:
@@ -20,56 +20,23 @@ Or install it yourself as:
 
 ## Usage
 
-### For Active Record models
-
-It has two tasks.
-
-* `copy_signature_files`: Copy type definition files for Rails from rbs_rails.
-* `generate_rbs_for_model`: Generate RBS files from model classes.
+Put the following code to `lib/tasks/rbs.rake`.
 
 ```ruby
-# Rakefile
+require 'rbs_rails/rake_task'
 
-task copy_signature_files: :environment do
-  require 'rbs_rails'
-
-  to = Rails.root.join('sig/rbs_rails/')
-  to.mkpath unless to.exist?
-  RbsRails.copy_signatures(to: to)
-end
-
-task generate_rbs_for_model: :environment do
-  require 'rbs_rails'
-
-  out_dir = Rails.root / 'sig'
-  out_dir.mkdir unless out_dir.exist?
-
-  Rails.application.eager_load!
-
-  ActiveRecord::Base.descendants.each do |klass|
-    next if klass.abstract_class?
-
-    path = out_dir / "app/models/#{klass.name.underscore}.rbs"
-    FileUtils.mkdir_p(path.dirname)
-
-    sig = RbsRails::ActiveRecord.class_to_rbs(klass)
-    path.write sig
-  end
-end
+RbsRails::RakeTask.new
 ```
 
-### For path helpers
+Then, the following four tasks are available.
 
-```ruby
-# Rakefile
+* `rbs_rails:copy_signature_files`: Copy RBS files for rbs_rails
+* `rbs_rails:generate_rbs_for_models`: Generate RBS files for Active Record models
+* `rbs_rails:generate_rbs_for_path_helpers`: Generate RBS files for path helpers
+* `rbs_rails:all`: Execute all tasks of RBS Rails
 
-task generate_rbs_for_path_helpers: :environment do
-  require 'rbs_rails'
-  out_path = Rails.root.join 'sig/path_helpers.rbs'
-  rbs = RbsRails::PathHelpers.generate
-  out_path.write rbs
-end
-```
+
+
 
 ### Steep integration
 

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -1,0 +1,73 @@
+require 'rake'
+require 'rake/tasklib'
+
+module RbsRails
+  class RakeTask < Rake::TaskLib
+    attr_accessor :ignore_model_if, :name
+
+    def initialize(name = :rbs_rails, &block)
+      super()
+
+      @name = name
+
+      block.call(self) if block
+
+      def_copy_signature_files
+      def_generate_rbs_for_models
+      def_generate_rbs_for_path_helpers
+      def_all
+    end
+
+    def def_all
+      desc 'Run all tasks of rbs_rails'
+
+      deps = [:"#{name}:copy_signature_files", :"#{name}:generate_rbs_for_models", :"#{name}:generate_rbs_for_path_helpers"]
+      task("#{name}:all": deps)
+    end
+
+    def def_copy_signature_files
+      desc 'Copy RBS files for rbs_rails'
+      task("#{name}:copy_signature_files": :environment) do
+        require 'rbs_rails'
+
+        to = Rails.root.join('sig/rbs_rails/')
+        to.mkpath unless to.exist?
+        RbsRails.copy_signatures(to: to)
+      end
+    end
+
+    def def_generate_rbs_for_models
+      desc 'Generate RBS files for Active Record models'
+      task("#{name}:generate_rbs_for_models": :environment) do
+        require 'rbs_rails'
+
+        out_dir = Rails.root / 'sig'
+        out_dir.mkdir unless out_dir.exist?
+
+        Rails.application.eager_load!
+
+        ::ActiveRecord::Base.descendants.each do |klass|
+          next if klass.abstract_class?
+          next if ignore_model_if && ignore_model_if.call(klass)
+
+          path = out_dir / "app/models/#{klass.name.underscore}.rbs"
+          FileUtils.mkdir_p(path.dirname)
+
+          sig = RbsRails::ActiveRecord.class_to_rbs(klass)
+          path.write sig
+        end
+      end
+    end
+
+    def def_generate_rbs_for_path_helpers
+      desc 'Generate RBS files for path helpers'
+      task("#{name}:generate_rbs_for_path_helpers": :environment) do
+        require 'rbs_rails'
+
+        out_path = Rails.root.join 'sig/path_helpers.rbs'
+        rbs = RbsRails::PathHelpers.generate
+        out_path.write rbs
+      end
+    end
+  end
+end

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -46,9 +46,11 @@ module RbsRails
 
         Rails.application.eager_load!
 
-        ::ActiveRecord::Base.descendants.each do |klass|
+        
+        # HACK: for steep
+        (_ = ::ActiveRecord::Base).descendants.each do |klass|
           next if klass.abstract_class?
-          next if ignore_model_if && ignore_model_if.call(klass)
+          next if ignore_model_if&.call(klass)
 
           path = out_dir / "app/models/#{klass.name.underscore}.rbs"
           FileUtils.mkdir_p(path.dirname)

--- a/sig/fileutils.rbs
+++ b/sig/fileutils.rbs
@@ -1,3 +1,4 @@
 module FileUtils
   def self.cp_r: (Pathname, Pathname) -> untyped
+  def self.mkdir_p: (String | Array[String], ?untyped) -> Array[String]
 end

--- a/sig/rake.rbs
+++ b/sig/rake.rbs
@@ -1,0 +1,6 @@
+module Rake
+  class TaskLib
+    def desc: (String) -> void
+    def task: (Hash[Symbol, Symbol | Array[Symbol]]) ?{ () -> void } -> void
+  end
+end

--- a/sig/rbs_rails/rake_task.rbs
+++ b/sig/rbs_rails/rake_task.rbs
@@ -1,0 +1,20 @@
+module RbsRails
+  class RakeTask < Rake::TaskLib
+    interface _Filter
+      def call: (Class) -> boolish
+    end
+    attr_accessor ignore_model_if: _Filter | nil
+
+    attr_accessor name: Symbol
+
+    def initialize: (?::Symbol name) { (self) -> void } -> void
+
+    def def_all: () -> void
+
+    def def_copy_signature_files: () -> void
+
+    def def_generate_rbs_for_models: () -> void
+
+    def def_generate_rbs_for_path_helpers: () -> void
+  end
+end

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rbs_rails (0.4.1)
+    rbs_rails (0.5.0)
       parser
       rbs (>= 0.20)
 
@@ -154,4 +154,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.2
+   2.2.3

--- a/test/app/Rakefile
+++ b/test/app/Rakefile
@@ -4,22 +4,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-task generate_rbs_for_model: :environment do
-  require 'rbs_rails'
-
-  out_dir = Pathname(File.expand_path('../sig', __dir__))
-  out_dir.mkdir unless out_dir.exist?
-
-  Rails.application.eager_load!
-
-  ActiveRecord::Base.descendants.each do |klass|
-    next if klass.abstract_class?
-
-    path = out_dir / "app/models/#{klass.name.underscore}.rbs"
-    FileUtils.mkdir_p(path.dirname)
-
-    sig = RbsRails::ActiveRecord.class_to_rbs(klass)
-    path.write sig
-  end
-end

--- a/test/app/Steepfile
+++ b/test/app/Steepfile
@@ -1,5 +1,5 @@
 target :app do
-  signature 'sig', "../sig"
+  signature 'sig'
   check "app/models"
 
   repo_path ENV['RBS_REPO_DIR'] || '../../gem_rbs/gems'

--- a/test/app/lib/tasks/rbs.rake
+++ b/test/app/lib/tasks/rbs.rake
@@ -1,0 +1,3 @@
+require 'rbs_rails/rake_task'
+
+RbsRails::RakeTask.new

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -4,15 +4,12 @@ class ActiveRecordTest < Minitest::Test
   def test_type_check
     clean_test_signatures
 
-    signature_path = Pathname(File.expand_path('../sig', __dir__))
-    RbsRails.copy_signatures(to: signature_path)
-
     dir = File.expand_path('../app', __dir__)
 
     Bundler.with_unbundled_env do
       sh!('bundle', 'install', chdir: dir)
       sh!('bin/rake', 'db:create', 'db:schema:load', chdir: dir)
-      sh!('bin/rake', 'generate_rbs_for_model', chdir: dir)
+      sh!('bin/rake', 'rbs_rails:all', chdir: dir)
     end
     sh!('steep', 'check', chdir: dir)
   end


### PR DESCRIPTION
We needed to deifne rake tasks by copying and pasting from README.
It isn't a good idea, so I add `RbsRails::RakeTask` to define rake tasks.


Previsouly I considered to use Rails Generator, but I guess providing `RbsRails::RakeTask` is better.
#7

Rails Generator create a file to user's Rails app directory. It is too customizable.
`RbsRails::RakeTask` is not more customizable than Rails Generator, but it is easier to change rake tasks code.