### PR TITLE
Re-structure signature directory

### DIFF
--- a/sig/rbs_rails/rake_task.rbs
+++ b/sig/rbs_rails/rake_task.rbs
@@ -7,6 +7,8 @@ module RbsRails
 
     attr_accessor name: Symbol
 
+    attr_accessor signature_root_dir: Pathname
+
     def initialize: (?::Symbol name) { (self) -> void } -> void
 
     def def_all: () -> void
@@ -16,5 +18,9 @@ module RbsRails
     def def_generate_rbs_for_models: () -> void
 
     def def_generate_rbs_for_path_helpers: () -> void
+
+    private
+
+    def setup_signature_root_dir!: () -> void
   end
 end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -15,7 +15,7 @@ class ActiveRecordTest < Minitest::Test
 
     setup!
 
-    rbs_path = Pathname(app_dir).join('sig/app/models/user.rbs')
+    rbs_path = Pathname(app_dir).join('sig/rbs_rails/app/models/user.rbs')
 
     assert_equal <<~RBS, rbs_path.read
       class User < ApplicationRecord

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 require 'pathname'
 require 'rbs_rails'
 
-TEST_SIG_DIR = Pathname(File.expand_path('./sig', __dir__))
+TEST_SIG_DIR = Pathname(File.expand_path('./app/sig/rbs_rails', __dir__))
 
 def clean_test_signatures
   File.delete(*TEST_SIG_DIR.glob('**/*.rbs'))


### PR DESCRIPTION
* All signature files are generated under `sig/rbs_rails/` directory
* Add `signature_root_dir` option to the rake task builder