### PR TITLE
Generate ActiveRecord models with namespaces and superclasses

### DIFF
--- a/lib/rbs_rails.rb
+++ b/lib/rbs_rails.rb
@@ -3,8 +3,10 @@ require 'rbs'
 require 'stringio'
 
 require_relative "rbs_rails/version"
+require_relative "rbs_rails/util"
 require_relative 'rbs_rails/active_record'
 require_relative 'rbs_rails/path_helpers'
+require_relative 'rbs_rails/dependency_builder'
 
 module RbsRails
   class Error < StandardError; end

--- a/lib/rbs_rails/dependency_builder.rb
+++ b/lib/rbs_rails/dependency_builder.rb
@@ -1,0 +1,43 @@
+module RbsRails
+  class DependencyBuilder
+    attr_reader :deps
+
+    def initialize
+      @deps = []
+    end
+
+    def build
+      dep_rbs = +""
+      done = Set.new(['ActiveRecord::Base', 'ActiveRecord', 'Object'])
+      deps.uniq!
+      while dep = deps.shift
+        next unless done.add?(dep)
+
+        case dep_object = Object.const_get(dep)
+        when Class
+          superclass = dep_object.superclass or raise
+          super_name = Util.module_name(superclass)
+          deps << super_name
+          dep_rbs << "class #{dep} < #{super_name} end\n"
+        when Module
+          dep_rbs << "module #{dep} end\n"
+        else
+          raise
+        end
+
+        # push namespaces
+        namespaces = dep.split('::')
+        namespaces.pop
+        namespaces.inject('') do |base, name|
+          full_name = base.empty? ? name : [base, name].join('::')
+          deps << full_name
+          full_name
+        end
+      end
+
+      unless dep_rbs.empty?
+        Util.format_rbs(dep_rbs)
+      end
+    end
+  end
+end

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -42,6 +42,8 @@ module RbsRails
         require 'rbs_rails'
 
         Rails.application.eager_load!
+
+        dep_builder = DependencyBuilder.new
         
         # HACK: for steep
         (_ = ::ActiveRecord::Base).descendants.each do |klass|
@@ -51,8 +53,12 @@ module RbsRails
           path = signature_root_dir / "app/models/#{klass.name.underscore}.rbs"
           path.dirname.mkpath
 
-          sig = RbsRails::ActiveRecord.class_to_rbs(klass)
+          sig = RbsRails::ActiveRecord.class_to_rbs(klass, dependencies: dep_builder.deps)
           path.write sig
+        end
+
+        if dep_rbs = dep_builder.build
+          signature_root_dir.join('model_dependencies.rbs').write(dep_rbs)
         end
       end
     end

--- a/lib/rbs_rails/util.rb
+++ b/lib/rbs_rails/util.rb
@@ -4,9 +4,15 @@ module RbsRails
 
     extend self
 
-    def module_name(mod)
-      # HACK: RBS doesn't have UnboundMethod#bind_call
-      (_ = MODULE_NAME).bind_call(mod)
+    if '2.7' <= RUBY_VERSION
+      def module_name(mod)
+        # HACK: RBS doesn't have UnboundMethod#bind_call
+        (_ = MODULE_NAME).bind_call(mod)
+      end
+    else
+      def module_name(mod)
+        MODULE_NAME.bind(mod).call
+      end
     end
 
     def format_rbs(rbs)

--- a/lib/rbs_rails/util.rb
+++ b/lib/rbs_rails/util.rb
@@ -1,0 +1,19 @@
+module RbsRails
+  module Util
+    MODULE_NAME = Module.instance_method(:name)
+
+    extend self
+
+    def module_name(mod)
+      # HACK: RBS doesn't have UnboundMethod#bind_call
+      (_ = MODULE_NAME).bind_call(mod)
+    end
+
+    def format_rbs(rbs)
+      decls = RBS::Parser.parse_signature(rbs)
+      StringIO.new.tap do |io|
+        RBS::Writer.new(out: io).write(decls)
+      end.string
+    end
+  end
+end

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -1,11 +1,11 @@
 module RbsRails::ActiveRecord
-  def self.class_to_rbs: (untyped klass) -> untyped
+  def self.class_to_rbs: (untyped klass, ?dependencies: Array[String]) -> untyped
 end
 
 class RbsRails::ActiveRecord::Generator
   @parse_model_file: nil | Parser::AST::Node
 
-  def initialize: (singleton(ActiveRecord::Base) klass) -> untyped
+  def initialize: (singleton(ActiveRecord::Base) klass, dependencies: Array[String]) -> untyped
 
   def generate: () -> String
 
@@ -16,6 +16,8 @@ class RbsRails::ActiveRecord::Generator
   def collection_proxy_decl: () -> String
 
   def header: () -> String
+
+  def footer: () -> String
 
   def associations: () -> String
 
@@ -55,5 +57,9 @@ class RbsRails::ActiveRecord::Generator
 
   def optional: (String) -> String
 
+  private
+
   attr_reader klass: singleton(ActiveRecord::Base)
+
+  attr_reader klass_name: String
 end

--- a/sig/rbs_rails/dependency_builder.rbs
+++ b/sig/rbs_rails/dependency_builder.rbs
@@ -1,0 +1,9 @@
+module RbsRails
+  class DependencyBuilder
+    attr_reader deps: Array[String]
+
+    def initialize: () -> void
+
+    def build: () -> (String | nil)
+  end
+end

--- a/sig/rbs_rails/util.rbs
+++ b/sig/rbs_rails/util.rbs
@@ -1,0 +1,11 @@
+module RbsRails
+  module Util
+    MODULE_NAME: UnboundMethod
+
+    extend Util
+
+    def module_name: (Module) -> String
+
+    def format_rbs: (String) -> String
+  end
+end


### PR DESCRIPTION
Fix #77 
Fix #66 



RBS Rails will generate model types with namespaces and superclasses by this pull request.


# Problem


Previously RBS Rails doesn't generate namespaces and superclasses types.
For example:

```ruby
# Ruby
module X
  class User < ApplicationRecord
  end
end

# RBS
module X::User < ApplicationRecord
end
```

It is correct RBS, but the user needs to define `X` and `ApplicationRecord` themselves.
It is inconvenient and confusing.


# Solution

Generate them.
So it will be the following.

```ruby
# RBS

module X
  class User < ApplicationRecord
  end
end

class ApplicationRecord < ActiveRecord::Base
end
```