### PR TITLE
Allow all kinds of argument for scope

### DIFF
--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rbs_rails (0.6.0)
+    rbs_rails (0.7.0)
       parser
       rbs (>= 1)
 

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -1,2 +1,4 @@
 class User < ApplicationRecord
+  scope :all_kind_args, -> (a, m = 1, n = 1, *rest, x, k: 1, **kwrest, &blk)  { all }
+  scope :no_arg, -> ()  { all }
 end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -76,9 +76,15 @@ class ActiveRecordTest < Minitest::Test
         def restore_updated_at!: () -> void
         def clear_updated_at_change: () -> void
 
+        def self.all_kind_args: (untyped a, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped kwrest) { (*untyped) -> untyped } -> ActiveRecord_Relation
+        def self.no_arg: () -> ActiveRecord_Relation
+
         class ActiveRecord_Relation < ActiveRecord::Relation
           include _ActiveRecord_Relation[User]
           include Enumerable[User]
+
+          def all_kind_args: (untyped a, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped kwrest) { (*untyped) -> untyped } -> ActiveRecord_Relation
+          def no_arg: () -> ActiveRecord_Relation
         end
 
         class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy


### PR DESCRIPTION
Fix #88 




The generator for Active Record raises an error with restarg, kwrestarg, and blockarg.
This pull request fixes the error.





