### PR TITLE
Remove hack for steep

### DIFF
--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -35,8 +35,7 @@ module RbsRails
 
         dep_builder = DependencyBuilder.new
         
-        # HACK: for steep
-        (_ = ::ActiveRecord::Base).descendants.each do |klass|
+        ::ActiveRecord::Base.descendants.each do |klass|
           next if klass.abstract_class?
           next if ignore_model_if&.call(klass)
 


### PR DESCRIPTION
Previously AR::Base.descendants is marked as a private method
accidentally, but it has been fixed by https://github.com/ruby/gem_rbs/pull/5