### PR TITLE
Skip generating RBS for class that doesn't have table in DB

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -1,6 +1,12 @@
 module RbsRails
   module ActiveRecord
 
+    def self.generatable?(klass)
+      return false if klass.abstract_class?
+
+      klass.connection.table_exists?(klass.table_name)
+    end
+
     def self.class_to_rbs(klass, dependencies: [])
       Generator.new(klass, dependencies: dependencies).generate
     end

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -36,7 +36,7 @@ module RbsRails
         dep_builder = DependencyBuilder.new
         
         ::ActiveRecord::Base.descendants.each do |klass|
-          next if klass.abstract_class?
+          next unless RbsRails::ActiveRecord.generatable?(klass)
           next if ignore_model_if&.call(klass)
 
           path = signature_root_dir / "app/models/#{klass.name.underscore}.rbs"

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -1,5 +1,6 @@
 module RbsRails::ActiveRecord
   def self.class_to_rbs: (untyped klass, ?dependencies: Array[String]) -> untyped
+  def self.generatable?: (untyped klass) -> boolish
 end
 
 class RbsRails::ActiveRecord::Generator


### PR DESCRIPTION
Close #81 

This pull request skips generating RBS for Active Record models if a model doesn't have a table in DB.


We can avoid errors like #81 by this change.

I think it is rare because we usually remove `require 'active_storage/engine` if the rails app doesn't use ActiveStorage.
But currently many people try to use RBS Rails with an empty rails app with `rails new`. In this case, I guess they don't care about `require 'active_storage/engine'`. So this change is meaningful.


