### PR TITLE
Define find method based on primary key

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -28,7 +28,7 @@ module RbsRails
       private def klass_decl
         <<~RBS
           #{header}
-            extend _ActiveRecord_Relation_ClassMethods[#{klass_name}, #{relation_class_name}]
+            extend _ActiveRecord_Relation_ClassMethods[#{klass_name}, #{relation_class_name}, #{pk_type}]
 
           #{columns}
           #{associations}
@@ -44,11 +44,18 @@ module RbsRails
         RBS
       end
 
+      private def pk_type
+        pk = klass.primary_key
+        col = klass.columns.find {|col| col.name == pk }
+        sql_type_to_class(col.type)
+      end
+
       private def relation_decl
         <<~RBS
           class #{relation_class_name} < ActiveRecord::Relation
-            include _ActiveRecord_Relation[#{klass_name}]
+            include _ActiveRecord_Relation[#{klass_name}, #{pk_type}]
             include Enumerable[#{klass_name}]
+
           #{enum_scope_methods(singleton: false)}
           #{scopes(singleton: false)}
           end

--- a/sig/activerecord.rbs
+++ b/sig/activerecord.rbs
@@ -1,0 +1,4 @@
+# TODO: Define it in gem_rbs_collection repository
+class ActiveRecord::Base
+  def self.primary_key: () -> String
+end

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -12,6 +12,8 @@ class RbsRails::ActiveRecord::Generator
 
   def klass_decl: () -> String
 
+  def pk_type: () -> String
+
   def relation_decl: () -> String
 
   def collection_proxy_decl: () -> String

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -19,7 +19,7 @@ class ActiveRecordTest < Minitest::Test
 
     assert_equal <<~RBS, rbs_path.read
       class User < ApplicationRecord
-        extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation]
+        extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation, Integer]
 
         attr_accessor id(): Integer
         def id_changed?: () -> bool
@@ -80,7 +80,7 @@ class ActiveRecordTest < Minitest::Test
         def self.no_arg: () -> ActiveRecord_Relation
 
         class ActiveRecord_Relation < ActiveRecord::Relation
-          include _ActiveRecord_Relation[User]
+          include _ActiveRecord_Relation[User, Integer]
           include Enumerable[User]
 
           def all_kind_args: (untyped a, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped kwrest) { (*untyped) -> untyped } -> ActiveRecord_Relation


### PR DESCRIPTION
Because the type of `primary_key` may be other than `Integer`, the class definition should include custom definitions.

We may want to extract the methods to an interface, or we can add another type parameter to `_ActiveRecord_Relation` and `_ActiveRecord_Relation_ClassMethods`.

```rbs
interface _ActiveRecord_Relation[Model, PrimaryKey]
  def find: (PrimaryKey) -> Model

  ...
end
```