### PR TITLE
Fix error on a table that doesn t have the pk

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -46,6 +46,8 @@ module RbsRails
 
       private def pk_type
         pk = klass.primary_key
+        return 'top' unless pk
+
         col = klass.columns.find {|col| col.name == pk }
         sql_type_to_class(col.type)
       end

--- a/test/app/app/models/blog.rb
+++ b/test/app/app/models/blog.rb
@@ -1,0 +1,3 @@
+class Blog < ApplicationRecord
+  has_and_belongs_to_many :users
+end

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
   scope :all_kind_args, -> (a, m = 1, n = 1, *rest, x, k: 1, **kwrest, &blk)  { all }
   scope :no_arg, -> ()  { all }
+
+  has_and_belongs_to_many :blogs
 end

--- a/test/app/db/migrate/20210414110904_create_blog_table_and_relation_to_user.rb
+++ b/test/app/db/migrate/20210414110904_create_blog_table_and_relation_to_user.rb
@@ -1,0 +1,13 @@
+class CreateBlogTableAndRelationToUser < ActiveRecord::Migration[6.1]
+  def change
+    create_table :blogs do |t|
+      t.string :title, null: false
+      t.string :description, null: false
+      t.belongs_to :user, null: false
+
+      t.timestamps
+    end
+
+    create_join_table :users, :blogs
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -2,15 +2,29 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_23_100326) do
+ActiveRecord::Schema.define(version: 2021_04_14_110904) do
+
+  create_table "blogs", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "description", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_blogs_on_user_id"
+  end
+
+  create_table "blogs_users", id: false, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "blog_id", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false


### PR DESCRIPTION
Fix #115 

HABTM (has_and_belongs_to_many) table doesn't have PK, but RBS Rails expected that PK exists in all tables. So it raises an error.

By this pull request, it treat PK type as `top` if PK doesn't exist. 


---


By the way, we still need to generate RBS for HABTM associations, same as `has_many`. But it is out-of-scope of this pull request.