### PR TITLE
Should be optional has_one and belongs_to associations

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -134,7 +134,7 @@ module RbsRails
           type = a.polymorphic? ? 'untyped' : Util.module_name(a.klass)
           type_optional = optional(type)
           <<~RUBY.chomp
-            def #{a.name}: () -> #{type}
+            def #{a.name}: () -> #{type_optional}
             def #{a.name}=: (#{type_optional}) -> #{type_optional}
             def build_#{a.name}: (untyped) -> #{type}
             def create_#{a.name}: (untyped) -> #{type}


### PR DESCRIPTION
`has_one` can be `nil` when none associated record.
And `belongs_to` can be `nil` when associated id is `nil`.
This change will help to find nilable object in model code.