### PR TITLE
Enum methods should be included GeneratedRelationMethods

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -59,6 +59,7 @@ module RbsRails
       private def generated_relation_methods_decl
         <<~RBS
           module GeneratedRelationMethods
+            #{enum_scope_methods(singleton: false)}
             #{scopes(singleton: false)}
             #{delegated_type_scope(singleton: false)}
           end
@@ -71,8 +72,6 @@ module RbsRails
             include GeneratedRelationMethods
             include _ActiveRecord_Relation[#{klass_name}, #{pk_type}]
             include Enumerable[#{klass_name}]
-
-          #{enum_scope_methods(singleton: false)}
           end
         RBS
       end

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -3,4 +3,9 @@ class User < ApplicationRecord
   scope :no_arg, -> ()  { all }
 
   has_and_belongs_to_many :blogs
+
+  enum status: {
+    temporary: 1,
+    accepted: 2,
+  }
 end

--- a/test/app/db/migrate/20200723100326_init.rb
+++ b/test/app/db/migrate/20200723100326_init.rb
@@ -3,6 +3,7 @@ class Init < ActiveRecord::Migration[6.0]
     create_table :users do |t|
       t.string :name, null: false
       t.integer :age, null: false
+      t.string :status, null: false
 
       t.timestamps null: false
     end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -106,10 +106,20 @@ class ActiveRecordTest < Minitest::Test
         def restore_updated_at!: () -> void
         def clear_updated_at_change: () -> void
 
+        def temporary!: () -> bool
+        def temporary?: () -> bool
+        def accepted!: () -> bool
+        def accepted?: () -> bool
+        def self.temporary: () -> ActiveRecord_Relation
+        def self.accepted: () -> ActiveRecord_Relation
         def self.all_kind_args: (untyped `type`, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped `untyped`) { (*untyped) -> untyped } -> ActiveRecord_Relation
         def self.no_arg: () -> ActiveRecord_Relation
 
         module GeneratedRelationMethods
+          def temporary: () -> ActiveRecord_Relation
+
+          def accepted: () -> ActiveRecord_Relation
+
           def all_kind_args: (untyped `type`, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped `untyped`) { (*untyped) -> untyped } -> ActiveRecord_Relation
 
           def no_arg: () -> ActiveRecord_Relation


### PR DESCRIPTION
Enum scope methods should be able to call by `Model::ActiveRecord_Associations_CollectionProxy`