### PR TITLE
include Relation to CollectionProxy

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -80,6 +80,7 @@ module RbsRails
         <<~RBS
           class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
             include GeneratedRelationMethods
+            include _ActiveRecord_Relation[#{klass_name}, #{pk_type}]
           end
         RBS
       end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -133,6 +133,7 @@ class ActiveRecordTest < Minitest::Test
 
         class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
           include GeneratedRelationMethods
+          include _ActiveRecord_Relation[User, Integer]
         end
       end
     RBS


### PR DESCRIPTION
gem_rbs_collection's [`_ActiveRecord_Relation`](https://github.com/ruby/gem_rbs_collection/blob/51880bed87fbc3dc8076fedb5cf798be05148220/gems/activerecord/6.0/activerecord.rbs#L92) emulates ruby class `Model::ActiveRecord_Relation`'s methods.

Then, the class relationship in ruby is as follows.
ref: https://github.com/rails/rails/blob/9f02d2d84ac84827b98add4199a7efafd0124eba/activerecord/lib/active_record/relation/delegation.rb#L13-L30

```rb
class ActiveRecord::Associations::CollectionProxy < ActiveRecord::Relation
end

class Model
  class ActiveRecord_Relation < ActiveRecord::Relation
  end
  class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
  end
end
```

If we expect `_ActiveRecord_Relation` to emulate `ActiveRecord::Relation`, then this change will expand the range of possible type support.