### PR TITLE
Modulize GeneratedAttributeMethods

### DIFF
--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -21,90 +21,188 @@ class ActiveRecordTest < Minitest::Test
       class User < ApplicationRecord
         extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation, Integer]
 
-        attr_accessor id(): Integer
-        def id_changed?: () -> bool
-        def id_change: () -> [ Integer?, Integer? ]
-        def id_will_change!: () -> void
-        def id_was: () -> Integer?
-        def id_previously_changed?: () -> bool
-        def id_previous_change: () -> Array[Integer?]?
-        def id_previously_was: () -> Integer?
-        def id_before_last_save: () -> Integer?
-        def id_change_to_be_saved: () -> Array[Integer?]?
-        def id_in_database: () -> Integer?
-        def saved_change_to_id: () -> Array[Integer?]?
-        def saved_change_to_id?: () -> bool
-        def will_save_change_to_id?: () -> bool
-        def restore_id!: () -> void
-        def clear_id_change: () -> void
+        module GeneratedAttributeMethods
+          def id: () -> Integer
 
-        attr_accessor name(): String
-        def name_changed?: () -> bool
-        def name_change: () -> [ String?, String? ]
-        def name_will_change!: () -> void
-        def name_was: () -> String?
-        def name_previously_changed?: () -> bool
-        def name_previous_change: () -> Array[String?]?
-        def name_previously_was: () -> String?
-        def name_before_last_save: () -> String?
-        def name_change_to_be_saved: () -> Array[String?]?
-        def name_in_database: () -> String?
-        def saved_change_to_name: () -> Array[String?]?
-        def saved_change_to_name?: () -> bool
-        def will_save_change_to_name?: () -> bool
-        def restore_name!: () -> void
-        def clear_name_change: () -> void
+          def id=: (Integer) -> Integer
 
-        attr_accessor age(): Integer
-        def age_changed?: () -> bool
-        def age_change: () -> [ Integer?, Integer? ]
-        def age_will_change!: () -> void
-        def age_was: () -> Integer?
-        def age_previously_changed?: () -> bool
-        def age_previous_change: () -> Array[Integer?]?
-        def age_previously_was: () -> Integer?
-        def age_before_last_save: () -> Integer?
-        def age_change_to_be_saved: () -> Array[Integer?]?
-        def age_in_database: () -> Integer?
-        def saved_change_to_age: () -> Array[Integer?]?
-        def saved_change_to_age?: () -> bool
-        def will_save_change_to_age?: () -> bool
-        def restore_age!: () -> void
-        def clear_age_change: () -> void
+          def id?: () -> bool
 
-        attr_accessor created_at(): ActiveSupport::TimeWithZone
-        def created_at_changed?: () -> bool
-        def created_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
-        def created_at_will_change!: () -> void
-        def created_at_was: () -> ActiveSupport::TimeWithZone?
-        def created_at_previously_changed?: () -> bool
-        def created_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
-        def created_at_previously_was: () -> ActiveSupport::TimeWithZone?
-        def created_at_before_last_save: () -> ActiveSupport::TimeWithZone?
-        def created_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
-        def created_at_in_database: () -> ActiveSupport::TimeWithZone?
-        def saved_change_to_created_at: () -> Array[ActiveSupport::TimeWithZone?]?
-        def saved_change_to_created_at?: () -> bool
-        def will_save_change_to_created_at?: () -> bool
-        def restore_created_at!: () -> void
-        def clear_created_at_change: () -> void
+          def id_changed?: () -> bool
 
-        attr_accessor updated_at(): ActiveSupport::TimeWithZone
-        def updated_at_changed?: () -> bool
-        def updated_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
-        def updated_at_will_change!: () -> void
-        def updated_at_was: () -> ActiveSupport::TimeWithZone?
-        def updated_at_previously_changed?: () -> bool
-        def updated_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
-        def updated_at_previously_was: () -> ActiveSupport::TimeWithZone?
-        def updated_at_before_last_save: () -> ActiveSupport::TimeWithZone?
-        def updated_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
-        def updated_at_in_database: () -> ActiveSupport::TimeWithZone?
-        def saved_change_to_updated_at: () -> Array[ActiveSupport::TimeWithZone?]?
-        def saved_change_to_updated_at?: () -> bool
-        def will_save_change_to_updated_at?: () -> bool
-        def restore_updated_at!: () -> void
-        def clear_updated_at_change: () -> void
+          def id_change: () -> [ Integer?, Integer? ]
+
+          def id_will_change!: () -> void
+
+          def id_was: () -> Integer?
+
+          def id_previously_changed?: () -> bool
+
+          def id_previous_change: () -> Array[Integer?]?
+
+          def id_previously_was: () -> Integer?
+
+          def id_before_last_save: () -> Integer?
+
+          def id_change_to_be_saved: () -> Array[Integer?]?
+
+          def id_in_database: () -> Integer?
+
+          def saved_change_to_id: () -> Array[Integer?]?
+
+          def saved_change_to_id?: () -> bool
+
+          def will_save_change_to_id?: () -> bool
+
+          def restore_id!: () -> void
+
+          def clear_id_change: () -> void
+
+          def name: () -> String
+
+          def name=: (String) -> String
+
+          def name?: () -> bool
+
+          def name_changed?: () -> bool
+
+          def name_change: () -> [ String?, String? ]
+
+          def name_will_change!: () -> void
+
+          def name_was: () -> String?
+
+          def name_previously_changed?: () -> bool
+
+          def name_previous_change: () -> Array[String?]?
+
+          def name_previously_was: () -> String?
+
+          def name_before_last_save: () -> String?
+
+          def name_change_to_be_saved: () -> Array[String?]?
+
+          def name_in_database: () -> String?
+
+          def saved_change_to_name: () -> Array[String?]?
+
+          def saved_change_to_name?: () -> bool
+
+          def will_save_change_to_name?: () -> bool
+
+          def restore_name!: () -> void
+
+          def clear_name_change: () -> void
+
+          def age: () -> Integer
+
+          def age=: (Integer) -> Integer
+
+          def age?: () -> bool
+
+          def age_changed?: () -> bool
+
+          def age_change: () -> [ Integer?, Integer? ]
+
+          def age_will_change!: () -> void
+
+          def age_was: () -> Integer?
+
+          def age_previously_changed?: () -> bool
+
+          def age_previous_change: () -> Array[Integer?]?
+
+          def age_previously_was: () -> Integer?
+
+          def age_before_last_save: () -> Integer?
+
+          def age_change_to_be_saved: () -> Array[Integer?]?
+
+          def age_in_database: () -> Integer?
+
+          def saved_change_to_age: () -> Array[Integer?]?
+
+          def saved_change_to_age?: () -> bool
+
+          def will_save_change_to_age?: () -> bool
+
+          def restore_age!: () -> void
+
+          def clear_age_change: () -> void
+
+          def created_at: () -> ActiveSupport::TimeWithZone
+
+          def created_at=: (ActiveSupport::TimeWithZone) -> ActiveSupport::TimeWithZone
+
+          def created_at?: () -> bool
+
+          def created_at_changed?: () -> bool
+
+          def created_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
+
+          def created_at_will_change!: () -> void
+
+          def created_at_was: () -> ActiveSupport::TimeWithZone?
+
+          def created_at_previously_changed?: () -> bool
+
+          def created_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def created_at_previously_was: () -> ActiveSupport::TimeWithZone?
+
+          def created_at_before_last_save: () -> ActiveSupport::TimeWithZone?
+
+          def created_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def created_at_in_database: () -> ActiveSupport::TimeWithZone?
+
+          def saved_change_to_created_at: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def saved_change_to_created_at?: () -> bool
+
+          def will_save_change_to_created_at?: () -> bool
+
+          def restore_created_at!: () -> void
+
+          def clear_created_at_change: () -> void
+
+          def updated_at: () -> ActiveSupport::TimeWithZone
+
+          def updated_at=: (ActiveSupport::TimeWithZone) -> ActiveSupport::TimeWithZone
+
+          def updated_at?: () -> bool
+
+          def updated_at_changed?: () -> bool
+
+          def updated_at_change: () -> [ ActiveSupport::TimeWithZone?, ActiveSupport::TimeWithZone? ]
+
+          def updated_at_will_change!: () -> void
+
+          def updated_at_was: () -> ActiveSupport::TimeWithZone?
+
+          def updated_at_previously_changed?: () -> bool
+
+          def updated_at_previous_change: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def updated_at_previously_was: () -> ActiveSupport::TimeWithZone?
+
+          def updated_at_before_last_save: () -> ActiveSupport::TimeWithZone?
+
+          def updated_at_change_to_be_saved: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def updated_at_in_database: () -> ActiveSupport::TimeWithZone?
+
+          def saved_change_to_updated_at: () -> Array[ActiveSupport::TimeWithZone?]?
+
+          def saved_change_to_updated_at?: () -> bool
+
+          def will_save_change_to_updated_at?: () -> bool
+
+          def restore_updated_at!: () -> void
+
+          def clear_updated_at_change: () -> void
+        end
+        include GeneratedAttributeMethods
 
         def temporary!: () -> bool
         def temporary?: () -> bool


### PR DESCRIPTION
Declare a method in the module that is automatically generated from the column name in Rails and include it.
This way, there is no possibility of conflicting declarations, and we can override any declarations in the model.

It also solves the problem of https://github.com/pocke/rbs_rails/issues/190