### PR TITLE
Fix CI of ruby head

### DIFF
--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -7,5 +7,6 @@ gem 'puma'
 gem 'bootsnap', require: false
 gem 'psych', '< 4' # for safe_load degration
 gem 'bcrypt'
+gem 'ostruct'
 
 gem 'rbs_rails', path: '../../'

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -7,6 +7,7 @@ gem 'puma'
 gem 'bootsnap', require: false
 gem 'psych', '< 4' # for safe_load degration
 gem 'bcrypt'
+gem 'rake'
 gem 'ostruct'
 
 gem 'rbs_rails', path: '../../'

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    ostruct (0.4.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     psych (3.3.2)
@@ -154,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   bootsnap
+  ostruct
   psych (< 4)
   puma
   rails (>= 6, < 7)

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -159,6 +159,7 @@ DEPENDENCIES
   psych (< 4)
   puma
   rails (>= 6, < 7)
+  rake
   rbs_rails!
   sqlite3
 


### PR DESCRIPTION
Current ruby head(0182bf615a)'s ostruct was broken.

```
rake aborted!
NoMethodError: undefined method `each' for false:FalseClass

        options.rakelib.each do |rlib|
                       ^^^^^
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:705:in `raw_load_rakefile'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:104:in `block in load_rakefile'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:186:in `standard_exception_handling'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:103:in `load_rakefile'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:82:in `block in run'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:186:in `standard_exception_handling'
/home/runner/.rubies/ruby-head/lib/ruby/gems/3.1.0/gems/rake-13.0.3/lib/rake/application.rb:80:in `run'
bin/rake:4:in `<main>'
```

However, this problem does not occur in gemfied ostruct v0.4.0