### PR TITLE
Disable bootsnap to fix CI on ruby-head

### DIFF
--- a/test/app/config/boot.rb
+++ b/test/app/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+# Disable Bootsnap due to https://github.com/pocke/rbs_rails/pull/198#issuecomment-931215730
+# require 'bootsnap/setup' # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Ref https://github.com/pocke/rbs_rails/pull/198#issuecomment-931215730


Close #198 