### PR TITLE
Should be set prefix for absolute namespace path

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -69,7 +69,7 @@ module RbsRails
 
       private def relation_decl
         <<~RBS
-          class #{relation_class_name} < ActiveRecord::Relation
+          class #{relation_class_name} < ::ActiveRecord::Relation
             include GeneratedRelationMethods
             include _ActiveRecord_Relation[#{klass_name}, #{pk_type}]
             include Enumerable[#{klass_name}]
@@ -79,7 +79,7 @@ module RbsRails
 
       private def collection_proxy_decl
         <<~RBS
-          class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+          class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
             include GeneratedRelationMethods
             include _ActiveRecord_Relation[#{klass_name}, #{pk_type}]
           end
@@ -98,7 +98,7 @@ module RbsRails
             superclass_name = Util.module_name(superclass)
             @dependencies << superclass_name
 
-            "class #{mod_name} < #{superclass_name}"
+            "class #{mod_name} < ::#{superclass_name}"
           when Module
             "module #{mod_name}"
           else

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -1,4 +1,4 @@
-class User < ApplicationRecord
+class User < ::ApplicationRecord
   extend _ActiveRecord_Relation_ClassMethods[User, ActiveRecord_Relation, Integer]
 
   module GeneratedAttributeMethods
@@ -214,13 +214,13 @@ class User < ApplicationRecord
     def no_arg: () -> ActiveRecord_Relation
   end
 
-  class ActiveRecord_Relation < ActiveRecord::Relation
+  class ActiveRecord_Relation < ::ActiveRecord::Relation
     include GeneratedRelationMethods
     include _ActiveRecord_Relation[User, Integer]
     include Enumerable[User]
   end
 
-  class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
+  class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
     include GeneratedRelationMethods
     include _ActiveRecord_Relation[User, Integer]
   end


### PR DESCRIPTION
gem [delayed_job_active_record](https://github.com/collectiveidea/delayed_job_active_record) use `ActiveRecord::Base` for superclass.
https://github.com/collectiveidea/delayed_job_active_record/blob/d65b0f9900f5b0c78c341c7c0209c2d138d64ec5/lib/delayed/backend/active_record.rb#L33

Then, `rbs_rails:all` task generate  following rbs file.

```rb
module Delayed
  module Backend
    module ActiveRecord
      class Job < ActiveRecord::Base
      class ActiveRecord_Relation < ActiveRecord::Relation
      class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
```

Then, `steep check` displays the following error.

```rb
sig/rbs_rails/app/models/delayed/backend/active_record/job.rbs:4:6: [error] Cannot find type `ActiveRecord::Base`
│ Diagnostic ID: RBS::UnknownTypeName
│
└       class Job < ActiveRecord::Base
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

sig/rbs_rails/app/models/delayed/backend/active_record/job.rbs:445:8: [error] Cannot find type `ActiveRecord::Relation`
│ Diagnostic ID: RBS::UnknownTypeName
│
└         class ActiveRecord_Relation < ActiveRecord::Relation
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

sig/rbs_rails/app/models/delayed/backend/active_record/job.rbs:451:8: [error] Cannot find type `ActiveRecord::Associations::CollectionProxy`
│ Diagnostic ID: RBS::UnknownTypeName
│
└         class ActiveRecord_Associations_CollectionProxy < ActiveRecord::Associations::CollectionProxy
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Detected 3 problems from 1 file
```

This PR fixes this problem as follows.

```rb
module Delayed
  module Backend
    module ActiveRecord
      class Job < ::ActiveRecord::Base
      class ActiveRecord_Relation < ::ActiveRecord::Relation
      class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
```