### PR TITLE
Create a module for each model to avoid conflicts

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -255,13 +255,13 @@ module RbsRails
                       end
 
           <<~EOS
-            module ::ActiveModel::SecurePassword::InstanceMethodsOnActivation_#{attribute}
+            module ActiveModel_SecurePassword_InstanceMethodsOnActivation_#{attribute}
               def #{attribute}=: (String) -> String
               def #{attribute}_confirmation=: (String) -> String
               def authenticate_#{attribute}: (String) -> (#{klass_name} | false)
               #{attribute == :password ? "alias authenticate authenticate_password" : ""}
             end
-            include ::ActiveModel::SecurePassword::InstanceMethodsOnActivation_#{attribute}
+            include ActiveModel_SecurePassword_InstanceMethodsOnActivation_#{attribute}
           EOS
         end.compact.join("\n")
       end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -184,7 +184,7 @@ class User < ApplicationRecord
   end
   include GeneratedAttributeMethods
 
-  module ::ActiveModel::SecurePassword::InstanceMethodsOnActivation_password
+  module ActiveModel_SecurePassword_InstanceMethodsOnActivation_password
     def password=: (String) -> String
 
     def password_confirmation=: (String) -> String
@@ -193,7 +193,7 @@ class User < ApplicationRecord
 
     alias authenticate authenticate_password
   end
-  include ::ActiveModel::SecurePassword::InstanceMethodsOnActivation_password
+  include ActiveModel_SecurePassword_InstanceMethodsOnActivation_password
 
   def temporary!: () -> bool
   def temporary?: () -> bool


### PR DESCRIPTION
If Rails app have more than one `has_secure_password`, the module names will conflict.