### PR TITLE
Fix CI for ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - run: bin/setup
+    # avoid using a precompiled nokogiri on head
+    - run: bundle config set force_ruby_platform true
+      if: ${{ matrix.ruby == 'head' }}
     - run: bundle exec rake


### PR DESCRIPTION
Avoid using the precompiled gem in the head.
ref: https://github.com/pocke/rbs_rails/pull/195