### PR TITLE
Remove platform x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,7 +163,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   minitest

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -149,7 +149,6 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
 
 DEPENDENCIES
   bcrypt


### PR DESCRIPTION
Because prebuild nokogiri doesn't support Ruby 3.2-dev