### PR TITLE
Remove some type definitions from parser

### DIFF
--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -1,14 +1,3 @@
-module Parser
-end
-
 class Parser::CurrentRuby
   def self.parse: (String) -> Parser::AST::Node
-end
-
-module Parser::AST
-end
-
-class Parser::AST::Node
-  def type: () -> Symbol
-  def children: () -> Array[untyped]
 end


### PR DESCRIPTION
When we run `steep check` we get the following error:

```
[error] Non-overloading method definition of `type` in `::Parser::AST::Node` cannot be duplicated
│ Diagnostic ID: RBS::DuplicatedMethodDefinition
│
└   def type: () -> Symbol
    ~~~~~~~~~~~~~~~~~~~~~~
```

It says "cannot be duplicated," so I checked and it appears that a type definitions for the `Parser` module has recently been added to Steep.
https://github.com/soutaro/steep/blob/56eab05da8872051ab258f5ddb32b576a4b73256/sig/shims/parser.rbs#L4-L6

Looking at the added rbs files, it appears that the `Parser` module, `Parser::AST` module, and `Parser::AST::Node` class have all been added.
Therefore, these definitions are removed.