### PR TITLE
FIX: RBS Rails writes blanks with RBS 3

### DIFF
--- a/lib/rbs_rails/util.rb
+++ b/lib/rbs_rails/util.rb
@@ -17,6 +17,7 @@ module RbsRails
 
     def format_rbs(rbs)
       decls = RBS::Parser.parse_signature(rbs)
+      decls = decls[1] + decls[2] if RBS::VERSION.start_with? '3.'
       StringIO.new.tap do |io|
         RBS::Writer.new(out: io).write(decls)
       end.string


### PR DESCRIPTION
Fix ISSUE #242

```
# parse_signature return 3 elements
def self.parse_signature(source)
    buf = buffer(source)
    dirs, decls = _parse_signature(buf, buf.last_position)

    [buf, dirs, decls]
end

# And write filter by type
def write(contents)
    dirs = contents.select {|c| c.is_a?(AST::Directives::Base) } #: Array[AST::Directives::t]
    decls = contents.select {|c| c.is_a?(AST::Declarations::Base) } #: Array[AST::Declarations::t]
    [...]
end

# It can be fixed with this code
def format_rbs(rbs)
    decls = RBS::Parser.parse_signature(rbs)
    decls = decls[1] + decls[2] if RBS::VERSION.start_with? '3.'
    StringIO.new.tap do |io|
        RBS::Writer.new(out: io).write(decls)
    end.string
end
```

https://github.com/ruby/rbs/compare/v2.8.4...v3.0.4 

![image](https://user-images.githubusercontent.com/11292703/225625872-f09c23e0-eee4-46bf-9cae-50614468bd02.png)
