### PR TITLE
Add RbsRails::ActionController::Generator

### DIFF
--- a/lib/rbs_rails.rb
+++ b/lib/rbs_rails.rb
@@ -4,6 +4,7 @@ require 'stringio'
 
 require_relative "rbs_rails/version"
 require_relative "rbs_rails/util"
+require_relative 'rbs_rails/action_controller'
 require_relative 'rbs_rails/active_record'
 require_relative 'rbs_rails/path_helpers'
 require_relative 'rbs_rails/dependency_builder'

--- a/lib/rbs_rails/action_controller.rb
+++ b/lib/rbs_rails/action_controller.rb
@@ -1,0 +1,54 @@
+module RbsRails
+  module ActionController
+
+    def self.user_defined_controller?(klass)
+      methods = klass.methods(false).map{|m| klass.method(m)} +
+        klass.instance_methods(false).map{|m| klass.instance_method(m)}
+      source_locations = methods.filter_map(&:source_location)
+      source_locations.first&.first&.start_with?(Rails.root.to_s)
+    end
+
+    def self.class_to_rbs(klass, dependencies: [])
+      Generator.new(klass, dependencies: dependencies).generate
+    end
+
+    class Generator
+      def initialize(klass, dependencies:)
+        @klass = klass
+      end
+
+      def generate
+        Util.format_rbs klass_decl
+      end
+
+      private def klass_decl
+        <<~RBS
+          #{header}
+          #{footer}
+        RBS
+      end
+
+      private def header
+        namespace = +''
+        module_defs = klass.module_parents.reverse[1..].map do |mod|
+          module_name = mod.name.split('::').last
+          "module #{module_name}"
+        end
+
+        superclass = _ = klass.superclass
+        superclass_name = Util.module_name(superclass)
+        class_name = klass.name.split('::').last
+        class_def = "class #{class_name} < ::#{superclass_name}"
+
+        (module_defs + [class_def]).join("\n")
+      end
+
+      private def footer
+        "end\n" * klass.module_parents.size
+      end
+
+      private
+      attr_reader :klass
+    end
+  end
+end

--- a/sig/rbs_rails/action_controller.rbs
+++ b/sig/rbs_rails/action_controller.rbs
@@ -1,0 +1,19 @@
+module RbsRails::ActionController
+  def self.user_defined_controller?: (untyped klass) -> boolish
+  def self.class_to_rbs: (untyped klass, ?dependencies: Array[String]) -> String
+end
+
+class RbsRails::ActionController::Generator
+  @klass: untyped
+
+  def initialize: (untyped klass, dependencies: Array[String]) -> String
+  def generate: () -> String
+
+  private
+
+  def klass_decl: () -> String
+  def header: () -> String
+  def footer: () -> String
+
+  attr_reader klass: untyped
+end

--- a/sig/rbs_rails/rake_task.rbs
+++ b/sig/rbs_rails/rake_task.rbs
@@ -15,6 +15,8 @@ module RbsRails
 
     def def_copy_signature_files: () -> void
 
+    def def_generate_rbs_for_controllers: () -> void
+
     def def_generate_rbs_for_models: () -> void
 
     def def_generate_rbs_for_path_helpers: () -> void


### PR DESCRIPTION
To support Action Controllers strongly depend on Rails autoloader, add a new generator RbsRails::ActionController::Generator.  It generates module definition automatically if controller classes are defined under modules.

This helps to generate correct types for Rails app defining controllers using shorthands (ex. `class Foo::Bar::BazController`).