### PR TITLE
Create signature_root_dir before generating path_helpers

### DIFF
--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -58,6 +58,7 @@ module RbsRails
       task("#{name}:generate_rbs_for_path_helpers": :environment) do
         require 'rbs_rails'
 
+        signature_root_dir.mkpath
         out_path = signature_root_dir.join 'path_helpers.rbs'
         rbs = RbsRails::PathHelpers.generate
         out_path.write rbs


### PR DESCRIPTION
Now, `generate_rbs_for_path_helpers` task does not check the signature_root_dir present.  So it would be crashed if sig/rbs_rails/ directory is not found.