### PR TITLE
Support optional parameter in build_** method for has_one associations

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -149,7 +149,7 @@ module RbsRails
           <<~RUBY.chomp
             def #{a.name}: () -> #{type_optional}
             def #{a.name}=: (#{type_optional}) -> #{type_optional}
-            def build_#{a.name}: (untyped) -> #{type}
+            def build_#{a.name}: (?untyped) -> #{type}
             def create_#{a.name}: (untyped) -> #{type}
             def create_#{a.name}!: (untyped) -> #{type}
             def reload_#{a.name}: () -> #{type_optional}

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -186,13 +186,13 @@ class User < ::ApplicationRecord
 
   def avatar_attachment: () -> ActiveStorage::Attachment?
   def avatar_attachment=: (ActiveStorage::Attachment?) -> ActiveStorage::Attachment?
-  def build_avatar_attachment: (untyped) -> ActiveStorage::Attachment
+  def build_avatar_attachment: (?untyped) -> ActiveStorage::Attachment
   def create_avatar_attachment: (untyped) -> ActiveStorage::Attachment
   def create_avatar_attachment!: (untyped) -> ActiveStorage::Attachment
   def reload_avatar_attachment: () -> ActiveStorage::Attachment?
   def avatar_blob: () -> ActiveStorage::Blob?
   def avatar_blob=: (ActiveStorage::Blob?) -> ActiveStorage::Blob?
-  def build_avatar_blob: (untyped) -> ActiveStorage::Blob
+  def build_avatar_blob: (?untyped) -> ActiveStorage::Blob
   def create_avatar_blob: (untyped) -> ActiveStorage::Blob
   def create_avatar_blob!: (untyped) -> ActiveStorage::Blob
   def reload_avatar_blob: () -> ActiveStorage::Blob?


### PR DESCRIPTION
This PR is to support optional parameters in the `build_**` method for has_one associations.
This helps bellow situation.

```ruby
 class User < ApplicationRecord
   has_one :profile
 end
 
 class Profile < ApplicationRecord
   belongs_to :user
 end
 
 profile = user.profile || User.build_profile
```

## before

```
$ bundle exec steep check

[error] More positional arguments are required
│ Diagnostic ID: Ruby::InsufficientPositionalArguments
│
└ profile = user.profile || User.build_profile
```

## after

```
$ bundle exec steep check

No type error detected. 🫖
```