### PR TITLE
Remove code for old Rubies

### DIFF
--- a/lib/rbs_rails/util.rb
+++ b/lib/rbs_rails/util.rb
@@ -4,15 +4,8 @@ module RbsRails
 
     extend self
 
-    if '2.7' <= RUBY_VERSION
-      def module_name(mod)
-        # HACK: RBS doesn't have UnboundMethod#bind_call
-        (_ = MODULE_NAME).bind_call(mod)
-      end
-    else
-      def module_name(mod)
-        MODULE_NAME.bind(mod).call
-      end
+    def module_name(mod)
+      MODULE_NAME.bind_call(mod)
     end
 
     def format_rbs(rbs)


### PR DESCRIPTION
RBS Rails only supports Ruby 3.0 or higher, so we do not need to care about Ruby 2.6, which does not have bind_call method