### PR TITLE
Support Rails7 style enum definitions

### DIFF
--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -9,8 +9,6 @@ class RbsRails::ActiveRecord::Generator
   @enum_definitions: Array[Hash[Symbol, untyped]]
   @klass_name: String
 
-  IGNORED_ENUM_KEYS: Array[Symbol]
-
   def initialize: (singleton(ActiveRecord::Base) klass, dependencies: Array[String]) -> untyped
 
   def generate: () -> String
@@ -51,14 +49,7 @@ class RbsRails::ActiveRecord::Generator
 
   def enum_scope_methods: (singleton: untyped `singleton`) -> String
 
-  def enum_definitions: () -> Array[Hash[Symbol, untyped]]
-
-  # We need static analysis to detect enum.
-  # ActiveRecord has `defined_enums` method,
-  # but it does not contain _prefix and _suffix information.
-  def build_enum_definitions: () -> Array[Hash[Symbol, untyped]]
-
-  def enum_method_name: (Hash[Symbol, untyped] hash, Symbol name, Symbol label) -> String
+  def enum_definitions: () -> Array[String]
 
   def scopes: (singleton: untyped `singleton`) -> untyped
 

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -221,20 +221,20 @@ class User < ::ApplicationRecord
   end
   include ActiveModel_SecurePassword_InstanceMethodsOnActivation_password
 
-  def temporary!: () -> bool
-  def temporary?: () -> bool
   def accepted!: () -> bool
   def accepted?: () -> bool
-  def self.temporary: () -> ::User::ActiveRecord_Relation
+  def temporary!: () -> bool
+  def temporary?: () -> bool
   def self.accepted: () -> ::User::ActiveRecord_Relation
+  def self.temporary: () -> ::User::ActiveRecord_Relation
   def self.all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
   def self.no_arg: () -> ::User::ActiveRecord_Relation
   def self.with_attached_avatar: () -> ::User::ActiveRecord_Relation
 
   module GeneratedRelationMethods
-    def temporary: () -> ::User::ActiveRecord_Relation
-
     def accepted: () -> ::User::ActiveRecord_Relation
+
+    def temporary: () -> ::User::ActiveRecord_Relation
 
     def all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
 


### PR DESCRIPTION
Since Rails7, the enum definition style has been changed.  This uses a private a private method `#_enum_methods_module` to obtain the registered enum defintions to support both Rails5 and Rails7.

Thanks to @ksss.  (refs: https://github.com/pocke/rbs_rails/issues/6)


This is yet another version of https://github.com/pocke/rbs_rails/pull/267 (static analytics approach).

* Pros
    * Very simple code
* Cons
    * Touch the internal of the Enum system