### PR TITLE
Fix CI for Ruby3.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    abbrev (0.1.2)
     actioncable (7.0.5)
       actionpack (= 7.0.5)
       activesupport (= 7.0.5)
@@ -155,7 +156,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (3.1.0)
+    rbs (3.4.3)
+      abbrev
     securerandom (0.2.2)
     steep (1.4.0)
       activesupport (>= 5.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
-    minitest (5.15.0)
+    minitest (5.21.1)
     net-imap (0.3.4)
       date
       net-protocol

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -10,4 +10,8 @@ gem 'bcrypt'
 
 gem 'rbs_rails', path: '../../'
 
-gem 'mutex_m'  # to run Rails6.1 under Ruby 3.4
+# to run Rails6.1 under Ruby 3.4
+gem 'base64'
+gem 'bigdecimal'
+gem 'drb'
+gem 'mutex_m'

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -9,3 +9,5 @@ gem 'psych', '< 4' # for safe_load degration
 gem 'bcrypt'
 
 gem 'rbs_rails', path: '../../'
+
+gem 'mutex_m'  # to run Rails6.1 under Ruby 3.4

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -68,12 +68,16 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
+    base64 (0.2.0)
     bcrypt (3.1.16)
+    bigdecimal (3.1.6)
     bootsnap (1.7.3)
       msgpack (~> 1.0)
     builder (3.2.4)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
+    drb (2.2.0)
+      ruby2_keywords
     erubi (1.10.0)
     globalid (1.0.1)
       activesupport (>= 5.0)
@@ -133,6 +137,7 @@ GEM
       thor (~> 1.0)
     rake (13.0.3)
     rbs (3.1.0)
+    ruby2_keywords (0.0.5)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -153,8 +158,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  base64
   bcrypt
+  bigdecimal
   bootsnap
+  drb
   mutex_m
   psych (< 4)
   puma

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     mini_portile2 (2.8.2)
     minitest (5.17.0)
     msgpack (1.4.2)
+    mutex_m (0.2.0)
     nio4r (2.5.8)
     nokogiri (1.15.2)
       mini_portile2 (~> 2.8.2)
@@ -154,6 +155,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   bootsnap
+  mutex_m
   psych (< 4)
   puma
   rails (>= 6, < 7)


### PR DESCRIPTION
Our CI with Ruby3.4 has been broken because the mutex_m gem has become the bundled gem since 3.4.

This fixes it via modifying dependencies.

* Upgrade minitest to v5.21.1 (latest)

     Old minitest depends on mutex_m gem (before v5.21) without explicit
     dependency.  This upgrade minitest to the latest version which does not depends on
     the mutex_m gem.

* Add mutex_m to the dependencies of test app

     Since Ruby 3.4, mutex_m gem becames the bundled gem.  So it should be
     listed on the dependencies list.

     Note: The latest activesupport now does not depends on it.  So it's also
     okay to upgrade it to the new one instead of adding.
