### PR TITLE
Add additional enum methods

### DIFF
--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -49,7 +49,7 @@ class RbsRails::ActiveRecord::Generator
 
   def enum_instance_methods: () -> String
 
-  def enum_scope_methods: (singleton: untyped `singleton`) -> String
+  def enum_class_methods: (singleton: untyped `singleton`) -> String
 
   def enum_definitions: () -> Array[Hash[Symbol, untyped]]
 

--- a/test/app/db/migrate/20240226015501_add_status_to_user.rb
+++ b/test/app/db/migrate/20240226015501_add_status_to_user.rb
@@ -1,0 +1,5 @@
+class AddStatusToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :status, :integer, null: false
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_14_110904) do
+ActiveRecord::Schema.define(version: 2024_02_26_015501) do
 
   create_table "blogs", force: :cascade do |t|
     t.string "title", null: false
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2021_04_14_110904) do
     t.integer "age", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", null: false
   end
 
 end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -181,6 +181,42 @@ class User < ::ApplicationRecord
     def restore_updated_at!: () -> void
 
     def clear_updated_at_change: () -> void
+
+    def status: () -> ::String
+
+    def status=: (::String) -> ::String
+
+    def status?: () -> bool
+
+    def status_changed?: () -> bool
+
+    def status_change: () -> [ ::String?, ::String? ]
+
+    def status_will_change!: () -> void
+
+    def status_was: () -> ::String?
+
+    def status_previously_changed?: () -> bool
+
+    def status_previous_change: () -> ::Array[::String?]?
+
+    def status_previously_was: () -> ::String?
+
+    def status_before_last_save: () -> ::String?
+
+    def status_change_to_be_saved: () -> ::Array[::String?]?
+
+    def status_in_database: () -> ::String?
+
+    def saved_change_to_status: () -> ::Array[::String?]?
+
+    def saved_change_to_status?: () -> bool
+
+    def will_save_change_to_status?: () -> bool
+
+    def restore_status!: () -> void
+
+    def clear_status_change: () -> void
   end
   include GeneratedAttributeMethods
 

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -261,16 +261,25 @@ class User < ::ApplicationRecord
   def temporary?: () -> bool
   def accepted!: () -> bool
   def accepted?: () -> bool
+  def self.statuses: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
   def self.temporary: () -> ::User::ActiveRecord_Relation
+  def self.not_temporary: () -> ::User::ActiveRecord_Relation
   def self.accepted: () -> ::User::ActiveRecord_Relation
+  def self.not_accepted: () -> ::User::ActiveRecord_Relation
   def self.all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
   def self.no_arg: () -> ::User::ActiveRecord_Relation
   def self.with_attached_avatar: () -> ::User::ActiveRecord_Relation
 
   module GeneratedRelationMethods
+    def statuses: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
+
     def temporary: () -> ::User::ActiveRecord_Relation
 
+    def not_temporary: () -> ::User::ActiveRecord_Relation
+
     def accepted: () -> ::User::ActiveRecord_Relation
+
+    def not_accepted: () -> ::User::ActiveRecord_Relation
 
     def all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
 


### PR DESCRIPTION
* Add negative scopes generated by `enum`.
* Add method that returns the mapping of enum name to database value.

Example:
```ruby
class User < ApplicationRecord
  enum status: {
    temporary: 1,
    accepted: 2
  }
end

# RBS is generated for these scopes
User.not_temporary
User.not_accepted
# RBS is generated for the mapping method
User.status # => { temporary: 1, accepted: 2 }
```