### PR TITLE
Fix #277: CollectionProxy should include Enumerable explicitly

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -83,6 +83,7 @@ module RbsRails
       private def collection_proxy_decl
         <<~RBS
           class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+            include ::Enumerable[#{klass_name}]
             include #{generated_relation_methods_name}
             include ::_ActiveRecord_Relation[#{klass_name}, #{pk_type}]
           end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -250,6 +250,7 @@ class User < ::ApplicationRecord
   end
 
   class ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+    include ::Enumerable[::User]
     include ::User::GeneratedRelationMethods
     include ::_ActiveRecord_Relation[::User, ::Integer]
   end


### PR DESCRIPTION
To precise the types of enumerable methods of CollectionProxy object,
this adds include statement to the generated CollectionProxy types.

refs: https://github.com/pocke/rbs_rails/issues/277

Note: this includes https://github.com/pocke/rbs_rails/pull/274.