### PR TITLE
Install _RbsRailsPathHelpers to ActionController::Base by default

### DIFF
--- a/lib/rbs_rails/path_helpers.rb
+++ b/lib/rbs_rails/path_helpers.rb
@@ -22,6 +22,12 @@ module RbsRails
         interface _RbsRailsPathHelpers
         #{methods.join("\n").indent(2)}
         end
+
+        module ::ActionController
+          class ::ActionController::Base
+            include ::_RbsRailsPathHelpers
+          end
+        end
       RBS
     end
 

--- a/test/expectations/path_helpers.rbs
+++ b/test/expectations/path_helpers.rbs
@@ -36,3 +36,9 @@ interface _RbsRailsPathHelpers
   def rails_storage_proxy_url: (*untyped) -> String
   def rails_storage_redirect_url: (*untyped) -> String
 end
+
+module ::ActionController
+  class ::ActionController::Base
+    include ::_RbsRailsPathHelpers
+  end
+end


### PR DESCRIPTION
Inside ActionController, the application routes are installed to
the ActionController::Base class on bootstrap automatically.

To follow the behavior, it's better to install `_RbsRailsPathHelpers` to
ActionController::Base by default.                                                                                                                                                                                     

refs:

* https://github.com/rails/rails/blob/v7.2.1/actionpack/lib/action_controller/railtie.rb#L75
* https://github.com/rails/rails/blob/v7.2.1/actionpack/lib/abstract_controller/railties/routes_helpers.rb#L18

Note: this includes https://github.com/pocke/rbs_rails/pull/274.