### PR TITLE
Call `ignore_model_if` before `RbsRails::ActiveRecord.generatable?`

### DIFF
--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -36,8 +36,8 @@ module RbsRails
         dep_builder = DependencyBuilder.new
         
         ::ActiveRecord::Base.descendants.each do |klass|
-          next unless RbsRails::ActiveRecord.generatable?(klass)
           next if ignore_model_if&.call(klass)
+          next unless RbsRails::ActiveRecord.generatable?(klass)
 
           path = signature_root_dir / "app/models/#{klass.name.underscore}.rbs"
           path.dirname.mkpath


### PR DESCRIPTION
`RbsRails::ActiveRecord.generatable?` may raise an exception.
For example, this occurred when using [ActiveType::Object](https://github.com/makandra/active_type).

```ruby
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "activerecord"
  gem "sqlite3"
  gem "rbs_rails"
  gem "active_type"
end

ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")

class X < ActiveType::Object
end

p RbsRails::ActiveRecord.generatable?(X)
```

```
% ruby -v ~/work/rbs_rails_test.rb
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [arm64-darwin22]
Fetching gem metadata from https://rubygems.org/........
Resolving dependencies...
/Users/ani/.rbenv/versions/3.3.5/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
/Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:1864:in `data_source_sql': NotImplementedError (NotImplementedError)
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:52:in `tables'
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:62:in `rescue in table_exists?'
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:59:in `table_exists?'
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs_rails-0.12.0/lib/rbs_rails/active_record.rb:7:in `generatable?'
        from /Users/ani/work/rbs_rails_test.rb:18:in `<main>'
/Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:1864:in `data_source_sql': NotImplementedError (NotImplementedError)
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/activerecord-7.2.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:60:in `table_exists?'
        from /Users/ani/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rbs_rails-0.12.0/lib/rbs_rails/active_record.rb:7:in `generatable?'
        from /Users/ani/work/rbs_rails_test.rb:18:in `<main>'
```

If we call `ignore_model_if` before `generatable?`, we can handle such cases by adding models that cause errors to `ignore_model_if`.