### PR TITLE
path_helpers: Support Rails 8.0

### DIFF
--- a/lib/rbs_rails/path_helpers.rb
+++ b/lib/rbs_rails/path_helpers.rb
@@ -1,6 +1,10 @@
 module RbsRails
   class PathHelpers
     def self.generate(routes: Rails.application.routes)
+      # Since Rails 8.0, route drawing has been deferred to the first request.
+      # This forcedly loads routes before generating path_helpers.
+      Rails.application.routes.eager_load!
+
       new(routes: Rails.application.routes).generate
     end
 


### PR DESCRIPTION
Since Rails 8.0, route drawing has been defered to the first request. This forcedly do route drawing to scan path_helpers.

refs: https://github.com/rails/rails/pull/52353