### PR TITLE
enum: Define enum mapping methods

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -39,6 +39,7 @@ module RbsRails
           #{delegated_type_instance}
           #{delegated_type_scope(singleton: true)}
           #{enum_instance_methods}
+          #{enum_mapping_methods}
           #{enum_scope_methods(singleton: true)}
           #{scopes(singleton: true)}
 
@@ -331,6 +332,16 @@ module RbsRails
         end
 
         methods.join("\n")
+      end
+
+      private def enum_mapping_methods
+        enum_definitions.flat_map do |hash|
+          hash.keys.filter_map do |name|
+            next if IGNORED_ENUM_KEYS.include?(name)
+
+            "def self.#{name.to_s.pluralize}: () -> ActiveSupport::HashWithIndifferentAccess[Symbol, untyped]"
+          end
+        end.join("\n")
       end
 
       private def enum_scope_methods(singleton:)

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -49,6 +49,8 @@ class RbsRails::ActiveRecord::Generator
 
   def enum_instance_methods: () -> String
 
+  def enum_mapping_methods: () -> String
+
   def enum_scope_methods: (singleton: untyped `singleton`) -> String
 
   def enum_definitions: () -> Array[Hash[Symbol, untyped]]

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -225,6 +225,7 @@ class User < ::ApplicationRecord
   def temporary?: () -> bool
   def accepted!: () -> bool
   def accepted?: () -> bool
+  def self.statuses: () -> ActiveSupport::HashWithIndifferentAccess[Symbol, untyped]
   def self.temporary: () -> ::User::ActiveRecord_Relation
   def self.accepted: () -> ::User::ActiveRecord_Relation
   def self.all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation


### PR DESCRIPTION
ActiveRecord generates enum mapping methods for each enum definition.

For example, the following enum definition generates `.statuses` method that returns a mapping from enum key to value.

```ruby
enum status: [:active, :inactive]
```

refs:

* https://api.rubyonrails.org/classes/ActiveRecord/Enum.html
* https://github.com/rails/rails/blob/v6.0.6.1/activerecord/lib/active_record/enum.rb#L163