### PR TITLE
deps: Add benchmark gem to test/app/Gemfile

### DIFF
--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -15,4 +15,7 @@ gem 'base64'
 gem 'bigdecimal'
 gem 'mutex_m'
 
+# They are bundled gems since Ruby 3.5
+gem 'benchmark'
+
 gem 'rbs_rails', path: '../../'

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rbs_rails (0.12.0)
+    rbs_rails (0.12.1)
       parser
       rbs (>= 1)
 
@@ -70,6 +70,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -176,6 +177,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   bcrypt
+  benchmark
   bigdecimal
   bootsnap
   mutex_m


### PR DESCRIPTION
Since ruby-3.5, the benchmark gem has been moved to the bundled gem from default gems. Therefore it should be loaded explicitly in Gemfile.

https://bugs.ruby-lang.org/issues/20309