### PR TITLE
sig: Remove sig/rake.rbs 

### DIFF
--- a/sig/rake.rbs
+++ b/sig/rake.rbs
@@ -1,6 +1,0 @@
-module Rake
-  class TaskLib
-    def desc: (String) -> void
-    def task: (Hash[Symbol, Symbol | Array[Symbol]]) ?{ () -> void } -> void
-  end
-end

--- a/test/app/Gemfile
+++ b/test/app/Gemfile
@@ -15,4 +15,7 @@ gem 'base64'
 gem 'bigdecimal'
 gem 'mutex_m'
 
+# They are bundled gems since Ruby 3.5
+gem 'benchmark'
+
 gem 'rbs_rails', path: '../../'

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    rbs_rails (0.12.0)
+    rbs_rails (0.12.1)
       parser
       rbs (>= 1)
 
@@ -70,6 +70,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    benchmark (0.4.0)
     bigdecimal (3.1.8)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -176,6 +177,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   bcrypt
+  benchmark
   bigdecimal
   bootsnap
   mutex_m


### PR DESCRIPTION
The signatures of Rake::TaskLib has been registered to
gem_rbs_collection.  Thefore custom types are no longer needed.
    
ref: https://github.com/ruby/gem_rbs_collection/blob/main/gems/rake/13.0/rake.rbs


Note: this includes https://github.com/pocke/rbs_rails/pull/294.