### PR TITLE
CI: Add GitHub Actions workflow for releasing gem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'lib/rbs_rails/version.rb'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can also run `bin/console` for an interactive prompt that will allow you to 
 This gem uses [RBS::Inline](https://github.com/soutaro/rbs-inline) to generate RBS files.  Please mark up your code with RBS comments.
 And then, run `bundle exec rake rbs_update` to reflect the type definitions to the RBS files.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and push it to the GitHub (via Pull Request).  Then, GitHub Actions will automatically create a release tag and publish the gem to rubygems.org.
 
 ## Contributing
 


### PR DESCRIPTION
This allows releasing a new gem package by changing the version.rb.  It helps to simplify and automate the release process.  It also helps not to grant permissions on rubygems.org to the co-maintainers  (See [Trusted publishing](https://guides.rubygems.org/trusted-publishing/)).

This workflow will be triggered when version.rb has been changed on the main branch.  And then, GitHub Action will create a new git tag with the version and release the HEAD of the main branch as a new gem.

Thanks to @sinsoku!


@pocke Could you add a trusted publishing setting at rubygems.org?
https://guides.rubygems.org/trusted-publishing/adding-a-publisher/

* Trusted publisher name: GitHub Actions
* Repository Owner: pocke
* Repository Name: rbs_rails
* workflow filename: release.yml

see details: https://guides.rubygems.org/trusted-publishing/adding-a-publisher/