### PR TITLE
enum: Support array-style enum declarations

### DIFF
--- a/sig/rbs_rails/active_record/enum.rbs
+++ b/sig/rbs_rails/active_record/enum.rbs
@@ -5,7 +5,13 @@ module RbsRails
     module Enum
       IGNORED_ENUM_KEYS: Array[Symbol]
 
-      @enum_definitions: Array[[ Hash[Symbol, untyped], Hash[Symbol, untyped] ]]
+      type definitions = Hash[Symbol, Array[Symbol] | Hash[Symbol, untyped]]
+
+      type options = Hash[Symbol, untyped]
+
+      type enum_definitions = Array[[ definitions, options ]]
+
+      @enum_definitions: enum_definitions
 
       def enum: (*untyped args, **untyped options) -> void
 

--- a/test/rbs_rails/enum_test.rb
+++ b/test/rbs_rails/enum_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+require 'active_record'
+
+class EnumTest < Minitest::Test
+  def test_array_enum
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: [:temporary, :accepted], _default: :temporary
+    end
+
+    assert_equal [[:status, "temporary"], [:status, "accepted"]], model.enum_definitions
+  end
+
+  def test_hash_enum
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: {
+        temporary: 1,
+        accepted: 2,
+      }, _default: :temporary
+    end
+
+    assert_equal [[:status, "temporary"], [:status, "accepted"]], model.enum_definitions
+  end
+
+  def test_enum_has_prefix
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: {
+        temporary: 1,
+        accepted: 2,
+      }, _prefix: true
+    end
+
+    assert_equal [[:status, "status_temporary"], [:status, "status_accepted"]], model.enum_definitions
+  end
+
+  def test_enum_named_prefix
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: {
+        temporary: 1,
+        accepted: 2,
+      }, _prefix: "prefix"
+    end
+
+    assert_equal [[:status, "prefix_temporary"], [:status, "prefix_accepted"]], model.enum_definitions
+  end
+
+  def test_enum_has_suffix
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: {
+        temporary: 1,
+        accepted: 2,
+      }, _suffix: true
+    end
+
+    assert_equal [[:status, "temporary_status"], [:status, "accepted_status"]], model.enum_definitions
+  end
+
+  def test_enum_named_suffix
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      enum status: {
+        temporary: 1,
+        accepted: 2,
+      }, _suffix: "suffix"
+    end
+
+    assert_equal [[:status, "temporary_suffix"], [:status, "accepted_suffix"]], model.enum_definitions
+  end
+end


### PR DESCRIPTION
The current implementation only supports hash-style enums.  But Rails also supports defining an enum via array-style.
https://api.rubyonrails.org/v6.1.7.10/classes/ActiveRecord/Enum.html

This supports array-style enum declarations.