### PR TITLE
Allow overrides methods in subclasses

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -42,7 +42,7 @@ module RbsRails
           # resolve-type-names: false
 
           #{header}
-            extend ::_ActiveRecord_Relation_ClassMethods[#{klass_name}, #{relation_class_name}, #{pk_type}]
+            extend ::ActiveRecord::Base::ClassMethods[#{klass_name}, #{relation_class_name}, #{pk_type}]
 
           #{columns}
           #{associations}
@@ -86,7 +86,7 @@ module RbsRails
         <<~RBS
           class #{relation_class_name} < ::ActiveRecord::Relation
             include #{generated_relation_methods_name}
-            include ::_ActiveRecord_Relation[#{klass_name}, #{pk_type}]
+            include ::ActiveRecord::Relation::Methods[#{klass_name}, #{pk_type}]
             include ::Enumerable[#{klass_name}]
           end
         RBS
@@ -97,7 +97,7 @@ module RbsRails
           class #{klass_name}::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
             include ::Enumerable[#{klass_name}]
             include #{generated_relation_methods_name}
-            include ::_ActiveRecord_Relation[#{klass_name}, #{pk_type}]
+            include ::ActiveRecord::Relation::Methods[#{klass_name}, #{pk_type}]
 
             def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> #{klass_name}
                      | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[#{klass_name}]

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -1,7 +1,7 @@
 # resolve-type-names: false
 
 class ::User < ::ApplicationRecord
-  extend ::_ActiveRecord_Relation_ClassMethods[::User, ::User::ActiveRecord_Relation, ::Integer]
+  extend ::ActiveRecord::Base::ClassMethods[::User, ::User::ActiveRecord_Relation, ::Integer]
 
   module ::User::GeneratedAttributeMethods
     def id: () -> ::Integer
@@ -400,14 +400,14 @@ class ::User < ::ApplicationRecord
 
   class ::User::ActiveRecord_Relation < ::ActiveRecord::Relation
     include ::User::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::User, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::User, ::Integer]
     include ::Enumerable[::User]
   end
 
   class ::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
     include ::Enumerable[::User]
     include ::User::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::User, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::User, ::Integer]
 
     def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> ::User
              | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[::User]


### PR DESCRIPTION
At present, we use two interfaces to define activerecord models;
`_ActiveRecord_Relation` and `_ActiveRecord_Relation_ClassMethods`.
However, these interfaces conflict with the overriding of method types
in the subclasses because Steep considers the overridden types to be
mismatched with the interface.

In ruby/gem_rbs_collection#413, I added two pseudo modules;
`ActiveRecord::Relation::Methods` and `ActiveRecord::Base::ClassMethods`.
They make the method types of the subclasses overridable without
conflicts because Steep allows overriding the method types in the
modules.

refs:

* https://github.com/pocke/rbs_rails/pull/254
* https://github.com/ruby/gem_rbs_collection/pull/413