### PR TITLE
test: Adjust expectations for Blog model

### DIFF
--- a/test/expectations/blog.rbs
+++ b/test/expectations/blog.rbs
@@ -226,6 +226,11 @@ class ::Blog < ::ApplicationRecord
   end
   include ::Blog::GeneratedAliasAttributeMethods
 
+  def users: () -> ::User::ActiveRecord_Associations_CollectionProxy
+  def users=: (::User::ActiveRecord_Associations_CollectionProxy | ::Array[::User]) -> (::User::ActiveRecord_Associations_CollectionProxy | ::Array[::User])
+  def user_ids: () -> ::Array[::Integer]
+  def user_ids=: (::Array[::Integer]) -> ::Array[::Integer]
+
   module ::Blog::GeneratedAssociationMethods
   end
   include ::Blog::GeneratedAssociationMethods


### PR DESCRIPTION
The generated methods for has_and_belongs_to_many association were missing for the blog model.