### PR TITLE
feat: Display class name when RBS generation fails

### DIFF
--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -74,6 +74,9 @@ module RbsRails
           sig = RbsRails::ActiveRecord.class_to_rbs(klass, dependencies: dep_builder.deps)
           path.write sig
           dep_builder.done << klass.name
+        rescue => e
+          puts "Error generating RBS for #{klass.name} model"
+          raise e
         end
 
         if dep_rbs = dep_builder.build


### PR DESCRIPTION
To resolve https://github.com/pocke/rbs_rails/issues/326 

There are cases where RBS auto-generation fails due to defects in model implementations. This PR enables developers to identify which model caused the problem when auto-generation failed.