### PR TITLE
Fix `#{attribute}_before_type_cast` and `{#attribute}_for_database` methods test

### DIFF
--- a/test/expectations/blog.rbs
+++ b/test/expectations/blog.rbs
@@ -40,6 +40,10 @@ class ::Blog < ::ApplicationRecord
 
     def clear_id_change: () -> void
 
+    def id_before_type_cast: () -> ::Integer
+
+    def id_for_database: () -> ::Integer
+
     def title: () -> ::String
 
     def title=: (::String) -> ::String
@@ -75,6 +79,10 @@ class ::Blog < ::ApplicationRecord
     def restore_title!: () -> void
 
     def clear_title_change: () -> void
+
+    def title_before_type_cast: () -> ::String
+
+    def title_for_database: () -> ::String
 
     def description: () -> ::String
 
@@ -112,6 +120,10 @@ class ::Blog < ::ApplicationRecord
 
     def clear_description_change: () -> void
 
+    def description_before_type_cast: () -> ::String
+
+    def description_for_database: () -> ::String
+
     def user_id: () -> ::Integer
 
     def user_id=: (::Integer) -> ::Integer
@@ -147,6 +159,10 @@ class ::Blog < ::ApplicationRecord
     def restore_user_id!: () -> void
 
     def clear_user_id_change: () -> void
+
+    def user_id_before_type_cast: () -> ::Integer
+
+    def user_id_for_database: () -> ::Integer
 
     def created_at: () -> ::ActiveSupport::TimeWithZone
 
@@ -184,6 +200,10 @@ class ::Blog < ::ApplicationRecord
 
     def clear_created_at_change: () -> void
 
+    def created_at_before_type_cast: () -> ::Time
+
+    def created_at_for_database: () -> ::Time
+
     def updated_at: () -> ::ActiveSupport::TimeWithZone
 
     def updated_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
@@ -219,6 +239,10 @@ class ::Blog < ::ApplicationRecord
     def restore_updated_at!: () -> void
 
     def clear_updated_at_change: () -> void
+
+    def updated_at_before_type_cast: () -> ::Time
+
+    def updated_at_for_database: () -> ::Time
   end
   include ::Blog::GeneratedAttributeMethods
   module ::Blog::GeneratedAliasAttributeMethods


### PR DESCRIPTION
In PR #322, type definitions for `#{attribute}_before_type_cast` and `#{attribute}_for_database` were added. However, these definitions are not added to `test/expectations/blog.rbs`, which is causing tests to fail. I will add the type definitions to `test/expectations/blog.rbs`.

before
---
```
bundle exec rake test

  1) Failure:
ActiveRecordTest#test_blog_model_rbs_snapshot [test/rbs_rails/active_record_test.rb:36]:
--- expected
+++ actual
@@ -40,6 +40,10 @@
 
     def clear_id_change: () -> void
 
+    def id_before_type_cast: () -> ::Integer
+
+    def id_for_database: () -> ::Integer
+
     def title: () -> ::String
 
     def title=: (::String) -> ::String
@@ -76,6 +80,10 @@
 
     def clear_title_change: () -> void
 
+    def title_before_type_cast: () -> ::String
+
+    def title_for_database: () -> ::String
+
     def description: () -> ::String
 
     def description=: (::String) -> ::String
@@ -111,6 +119,10 @@
     def restore_description!: () -> void
 
     def clear_description_change: () -> void
+
+    def description_before_type_cast: () -> ::String
+
+    def description_for_database: () -> ::String
 
     def user_id: () -> ::Integer
 
@@ -148,6 +160,10 @@
 
     def clear_user_id_change: () -> void
 
+    def user_id_before_type_cast: () -> ::Integer
+
+    def user_id_for_database: () -> ::Integer
+
     def created_at: () -> ::ActiveSupport::TimeWithZone
 
     def created_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
@@ -184,6 +200,10 @@
 
     def clear_created_at_change: () -> void
 
+    def created_at_before_type_cast: () -> ::Time
+
+    def created_at_for_database: () -> ::Time
+
     def updated_at: () -> ::ActiveSupport::TimeWithZone
 
     def updated_at=: (::ActiveSupport::TimeWithZone) -> ::ActiveSupport::TimeWithZone
@@ -219,6 +239,10 @@
     def restore_updated_at!: () -> void
 
     def clear_updated_at_change: () -> void
+
+    def updated_at_before_type_cast: () -> ::Time
+
+    def updated_at_for_database: () -> ::Time
   end
   include ::Blog::GeneratedAttributeMethods
   module ::Blog::GeneratedAliasAttributeMethods


19 runs, 17 assertions, 1 failures, 0 errors, 0 skips
```

after
---
```
bundle exec rake test

Finished in 19.216819s, 0.9887 runs/s, 0.8846 assertions/s.

19 runs, 17 assertions, 0 failures, 0 errors, 0 skips
```