### PR TITLE
Support no-arguments in `create_association` `create_association!` method

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -197,8 +197,8 @@ module RbsRails
             def #{a.name}: () -> #{type_optional}
             def #{a.name}=: (#{type_optional}) -> #{type_optional}
             def build_#{a.name}: (?untyped) -> #{type}
-            def create_#{a.name}: (untyped) -> #{type}
-            def create_#{a.name}!: (untyped) -> #{type}
+            def create_#{a.name}: (?untyped) -> #{type}
+            def create_#{a.name}!: (?untyped) -> #{type}
             def reload_#{a.name}: () -> #{type_optional}
           RUBY
         end.join("\n")

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -417,14 +417,14 @@ class ::User < ::ApplicationRecord
   def avatar_attachment: () -> ::ActiveStorage::Attachment?
   def avatar_attachment=: (::ActiveStorage::Attachment?) -> ::ActiveStorage::Attachment?
   def build_avatar_attachment: (?untyped) -> ::ActiveStorage::Attachment
-  def create_avatar_attachment: (untyped) -> ::ActiveStorage::Attachment
-  def create_avatar_attachment!: (untyped) -> ::ActiveStorage::Attachment
+  def create_avatar_attachment: (?untyped) -> ::ActiveStorage::Attachment
+  def create_avatar_attachment!: (?untyped) -> ::ActiveStorage::Attachment
   def reload_avatar_attachment: () -> ::ActiveStorage::Attachment?
   def avatar_blob: () -> ::ActiveStorage::Blob?
   def avatar_blob=: (::ActiveStorage::Blob?) -> ::ActiveStorage::Blob?
   def build_avatar_blob: (?untyped) -> ::ActiveStorage::Blob
-  def create_avatar_blob: (untyped) -> ::ActiveStorage::Blob
-  def create_avatar_blob!: (untyped) -> ::ActiveStorage::Blob
+  def create_avatar_blob: (?untyped) -> ::ActiveStorage::Blob
+  def create_avatar_blob!: (?untyped) -> ::ActiveStorage::Blob
   def reload_avatar_blob: () -> ::ActiveStorage::Blob?
 
   module ::User::GeneratedAssociationMethods


### PR DESCRIPTION
This PR is to support optional parameters in the`create_association` `create_association!`.
This helps bellow situation.

```rb
class User < ApplicationRecord
  has_one :profile
end
 
class Profile < ApplicationRecord
  belongs_to :user
end

user = User.first
user.create_profile! 
```