### PR TITLE
feat: Add command line interface for rbs_rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 gem 'rails', '>= 7.0'
 gem 'rbs', '>= 3'
-gem 'rbs-inline'
+gem 'rbs-inline', require: false
 gem 'steep', '>= 1.4'
 gem 'minitest'

--- a/README.md
+++ b/README.md
@@ -26,19 +26,12 @@ Run the following command. It generates `lib/tasks/rbs.rake`.
 $ bin/rails g rbs_rails:install
 ```
 
-Then, the following four tasks are available.
+Then, the following three tasks are available.
 
-* `rbs_rails:prepare`: Install inspector modules for Active Record models.  This task is required to run before loading Rails application.
 * `rbs_rails:generate_rbs_for_models`: Generate RBS files for Active Record models
 * `rbs_rails:generate_rbs_for_path_helpers`: Generate RBS files for path helpers
 * `rbs_rails:all`: Execute all tasks of RBS Rails
 
-
-If you invoke multiple tasks, please run `rbs_rails:prepare` first.
-
-```console
-$ bin/rails rbs_rails:prepare some_task another_task rbs_rails:generate_rbs_for_models
-```
 
 ### Install RBS for `rails` gem
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Then, the following three tasks are available.
 * `rbs_rails:generate_rbs_for_path_helpers`: Generate RBS files for path helpers
 * `rbs_rails:all`: Execute all tasks of RBS Rails
 
+You can also run rbs_rails from command line:
+
+```console
+# Generate all RBS files
+$ bundle exec rbs_rails all
+
+# Generate RBS files for models
+$ bundle exec rbs_rails models
+
+# Generate RBS files for path helpers
+$ bundle exec rbs_rails path_helpers
+```
 
 ### Install RBS for `rails` gem
 
@@ -44,6 +56,31 @@ You need to install `rails` gem's RBS files. I highly recommend using `rbs colle
    $ bundle exec rbs collection init
    $ bundle exec rbs collection install
    ```
+
+### Configuration
+
+You can customize the behavior of rbs_rails via configuration file. Place one of the following files in your project:
+
+* `.rbs_rails.rb` (in the project root)
+* `config/rbs_rails.rb`
+
+```ruby
+RbsRails.configure do |config|
+  # Specify the directory where RBS signatures will be generated
+  # Default: Rails.root.join("sig/rbs_rails")
+  config.signature_root_dir = "sig/rbs_rails"
+
+  # Define which models should be ignored during generation
+  config.ignore_model_if do |klass|
+    # Example: Ignore test models
+    klass.name.start_with?("Test") ||
+    # Example: Ignore models in specific namespaces
+    klass.name.start_with?("Admin::") ||
+    # Example: Ignore models without database tables
+    !klass.table_exists?
+  end
+end
+```
 
 ### Steep integration
 

--- a/example/rbs_rails.rb
+++ b/example/rbs_rails.rb
@@ -1,0 +1,22 @@
+# Example configuration file for rbs_rails
+#
+# Place this file in the root of your Rails project or in config/rbs_rails.rb
+
+RbsRails.configure do |config|
+  # Specify the directory where RBS signatures will be generated
+  # Default: Rails.root.join("sig/rbs_rails")
+  config.signature_root_dir = "sig/rbs_rails"
+
+  # Define a proc to determine which models should be ignored during generation
+  # The proc receives a model class and should return true if the model should be ignored
+  config.ignore_model_if do |klass|
+    # Example: Ignore test models
+    klass.name.start_with?("Test") ||
+    # Example: Ignore models in the Admin namespace
+    klass.name.start_with?("Admin::") ||
+    # Example: Ignore models that are not backed by a database table
+    !klass.table_exists? ||
+    # Example: Ignore anonymous classes
+    klass.name.blank?
+  end
+end

--- a/exe/rbs_rails
+++ b/exe/rbs_rails
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require "rbs_rails"
+require "rbs_rails/cli"
+
+exit RbsRails::CLI.new().run(ARGV)

--- a/lib/generators/rbs_rails/install_generator.rb
+++ b/lib/generators/rbs_rails/install_generator.rb
@@ -8,18 +8,9 @@ module RbsRails
           require 'rbs_rails/rake_task'
 
           RbsRails::RakeTask.new do |task|
-            # If you want to avoid generating RBS for some classes, comment in it.
-            # default: nil
-            #
-            # task.ignore_model_if = -> (klass) { klass == MyClass }
-
             # If you want to change the rake task namespace, comment in it.
             # default: :rbs_rails
             # task.name = :cool_rbs_rails
-
-            # If you want to change where RBS Rails writes RBSs into, comment in it.
-            # default: Rails.root / 'sig/rbs_rails'
-            # task.signature_root_dir = Rails.root / 'my_sig/rbs_rails'
           end
         rescue LoadError
           # failed to load rbs_rails. Skip to load rbs_rails tasks.

--- a/lib/rbs_rails/cli.rb
+++ b/lib/rbs_rails/cli.rb
@@ -80,6 +80,8 @@ module RbsRails
       install_hooks
 
       Rails.application.initialize!
+    rescue LoadError => e
+      raise "Failed to load Rails application: #{e.message}"
     end
 
     def install_hooks #: void

--- a/lib/rbs_rails/cli.rb
+++ b/lib/rbs_rails/cli.rb
@@ -1,0 +1,145 @@
+require "optparse"
+
+module RbsRails
+  class CLI
+    attr_reader :options #: Hash[Symbol, untyped]
+
+    def initialize #: void
+      @options = {}
+    end
+
+    # @rbs argv: Array[String]
+    def run(argv) #: Integer
+      parser = create_option_parser
+
+      begin
+        args = parser.parse(argv)
+        subcommand = args.shift || "help"
+
+        case subcommand
+        when "help"
+          $stdout.puts parser.help
+          0
+        when "version"
+          $stdout.puts "rbs_rails #{RbsRails::VERSION}"
+          0
+        when "all"
+          load_application
+          generate_models
+          generate_path_helpers
+          0
+        when "models"
+          load_application
+          generate_models
+          0
+        when "path_helpers"
+          load_application
+          generate_path_helpers
+          0
+        else
+          $stdout.puts "Unknown command: #{subcommand}"
+          $stdout.puts parser.help
+          1
+        end
+      rescue OptionParser::InvalidOption => e
+        $stderr.puts "Error: #{e.message}"
+        $stdout.puts parser.help
+        1
+      end
+    rescue StandardError => e
+      $stderr.puts "Error: #{e.message}"
+      1
+    end
+
+    private
+
+    def load_application #: void
+      require_relative "#{Dir.getwd}/config/application"
+
+      install_hooks
+
+      Rails.application.initialize!
+    end
+
+    def install_hooks #: void
+      # Load inspectors.  This is necessary to load earlier than Rails application.
+      require 'rbs_rails/active_record/enum'
+    end
+
+    def generate_models #: void
+      Rails.application.eager_load!
+
+      dep_builder = DependencyBuilder.new
+
+      ::ActiveRecord::Base.descendants.each do |klass|
+        generate_single_model(klass, dep_builder)
+      rescue => e
+        puts "Error generating RBS for #{klass.name} model"
+        raise e
+      end
+
+      if dep_rbs = dep_builder.build
+        signature_root_dir.join('model_dependencies.rbs').write(dep_rbs)
+      end
+    end
+
+    # @rbs klass: singleton(ActiveRecord::Base)
+    # @rbs dep_builder: DependencyBuilder
+    def generate_single_model(klass, dep_builder) #: bool
+      # next if ignore_model_if&.call(klass)
+      return false unless RbsRails::ActiveRecord.generatable?(klass)
+
+      original_path, _line = Object.const_source_location(klass.name) rescue nil
+
+      rbs_relative_path = if original_path && Pathname.new(original_path).fnmatch?("#{Rails.root}/**")
+                            Pathname.new(original_path)
+                                    .relative_path_from(Rails.root)
+                                    .sub_ext('.rbs')
+                          else
+                            "app/models/#{klass.name.underscore}.rbs"
+                          end
+
+      path = signature_root_dir / rbs_relative_path
+      path.dirname.mkpath
+
+      sig = RbsRails::ActiveRecord.class_to_rbs(klass, dependencies: dep_builder.deps)
+      path.write sig
+      dep_builder.done << klass.name
+
+      true
+    end
+
+    def generate_path_helpers #: void
+      path = signature_root_dir.join 'path_helpers.rbs'
+      path.dirname.mkpath
+
+      sig = RbsRails::PathHelpers.generate
+      path.write sig
+    end
+
+    def create_option_parser #: OptionParser
+      OptionParser.new do |opts|
+        opts.banner = <<~BANNER
+          Usage: rbs_rails [command] [options]
+
+          Commands:
+                  help           Show this help message
+                  version        Show version
+                  all            Generate all RBS files
+                  models         Generate RBS files for models
+                  path_helpers   Generate RBS for Rails path helpers
+
+          Options:
+        BANNER
+
+        opts.on("--signature-root-dir=DIR", "Specify the root directory for RBS signatures") do |dir|
+          @options[:signature_root_dir] = Pathname.new(dir)
+        end
+      end
+    end
+
+    def signature_root_dir #: Pathname
+      @options[:signature_root_dir] || Rails.root.join("sig/rbs_rails")
+    end
+  end
+end

--- a/lib/rbs_rails/cli/configuration.rb
+++ b/lib/rbs_rails/cli/configuration.rb
@@ -1,0 +1,63 @@
+require 'forwardable'
+require 'singleton'
+
+module RbsRails
+  class CLI
+    class Configuration
+      include Singleton
+
+      # @rbs!
+      #   def self.instance: () -> Configuration
+      #   def self.configure: () { (Configuration) -> void } -> void
+
+      class << self
+        extend Forwardable
+
+        def_delegator :instance, :configure  # steep:ignore
+      end
+
+      # @rbs!
+      #   @signature_root_dir: Pathname?
+      #   @ignore_model_if: (^(singleton(ActiveRecord::Base)) -> bool)?
+
+      def initialize #: void
+        @signature_root_dir = nil
+        @ignore_model_if = nil
+      end
+
+      # @rbs &block: (Configuration) -> void
+      def configure(&block) #: void
+        block.call(self)
+      end
+
+      def signature_root_dir #: Pathname
+        @signature_root_dir || Rails.root.join("sig/rbs_rails")
+      end
+
+      # @rbs dir: String | Pathname
+      def signature_root_dir=(dir) #: Pathname
+        @signature_root_dir = case dir
+                            when String
+                              Pathname.new(dir)
+                            when Pathname
+                              dir
+                            else
+                              raise ArgumentError, "signature_root_dir must be String or Pathname"
+                            end
+      end
+
+      # @rbs &block: (singleton(ActiveRecord::Base)) -> bool
+      def ignore_model_if(&block) #: void
+        @ignore_model_if = block
+      end
+
+      # @rbs klass: singleton(ActiveRecord::Base)
+      def ignored_model?(klass) #: bool
+        ignore_model_if = @ignore_model_if
+        return false unless ignore_model_if
+
+        ignore_model_if.call(klass)
+      end
+    end
+  end
+end

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -10,7 +10,7 @@ module RbsRails
 
     attr_accessor :ignore_model_if #: _Filter | nil
     attr_accessor :name #: Symbol
-    attr_writer :signature_root_dir #: Pathname
+    attr_writer :signature_root_dir #: Pathname?
 
     # @rbs name: ::Symbol
     # @rbs &block: (RbsRails::RakeTask) -> void
@@ -18,7 +18,7 @@ module RbsRails
       super()
 
       @name = name
-      @signature_root_dir = Rails.root / 'sig/rbs_rails'
+      @signature_root_dir = nil
 
       block.call(self) if block
 
@@ -30,7 +30,11 @@ module RbsRails
     def def_all #: void
       desc 'Run all tasks of rbs_rails'
       task :"#{name}:all" do
-        sh "rbs_rails", "all", "--signature-root-dir=#{signature_root_dir}"
+        if signature_root_dir
+          sh "rbs_rails", "all", "--signature-root-dir=#{signature_root_dir}"
+        else
+          sh "rbs_rails", "all"
+        end
       end
     end
 
@@ -39,19 +43,29 @@ module RbsRails
       task :"#{name}:generate_rbs_for_models" do
         warn "ignore_model_if is deprecated." if ignore_model_if
 
-        sh "rbs_rails", "models", "--signature-root-dir=#{signature_root_dir}"
+        if signature_root_dir
+          sh "rbs_rails", "models", "--signature-root-dir=#{signature_root_dir}"
+        else
+          sh "rbs_rails", "models"
+        end
       end
     end
 
     def def_generate_rbs_for_path_helpers #: void
       desc 'Generate RBS files for path helpers'
       task :"#{name}:generate_rbs_for_path_helpers" do
-        sh "rbs_rails", "path_helpers", "--signature-root-dir=#{signature_root_dir}"
+        if signature_root_dir
+          sh "rbs_rails", "path_helpers", "--signature-root-dir=#{signature_root_dir}"
+        else
+          sh "rbs_rails", "path_helpers"
+        end
       end
     end
 
-    private def signature_root_dir #: Pathname
-      Pathname(@signature_root_dir)
+    private def signature_root_dir #: Pathname?
+      if path = @signature_root_dir
+        Pathname(path)
+      end
     end
   end
 end

--- a/lib/rbs_rails/rake_task.rb
+++ b/lib/rbs_rails/rake_task.rb
@@ -22,7 +22,6 @@ module RbsRails
 
       block.call(self) if block
 
-      def_prepare
       def_generate_rbs_for_models
       def_generate_rbs_for_path_helpers
       def_all
@@ -30,76 +29,29 @@ module RbsRails
 
     def def_all #: void
       desc 'Run all tasks of rbs_rails'
-
-      deps = [:"#{name}:prepare",
-              :"#{name}:generate_rbs_for_models",
-              :"#{name}:generate_rbs_for_path_helpers"]
-      task("#{name}:all": deps)
-    end
-
-    def def_prepare
-      desc 'Prepare rbs_rails'
-      task "#{name}:prepare" do
-        # Load inspectors.  This is necessary to load earlier than Rails application.
-        require 'rbs_rails/active_record/enum'
+      task :"#{name}:all" do
+        sh "rbs_rails", "all", "--signature-root-dir=#{signature_root_dir}"
       end
     end
 
     def def_generate_rbs_for_models #: void
       desc 'Generate RBS files for Active Record models'
-      task("#{name}:generate_rbs_for_models": [:"#{name}:prepare", :environment]) do
-        require 'rbs_rails'
+      task :"#{name}:generate_rbs_for_models" do
+        warn "ignore_model_if is deprecated." if ignore_model_if
 
-        Rails.application.eager_load!
-
-        dep_builder = DependencyBuilder.new
-
-        ::ActiveRecord::Base.descendants.each do |klass|
-          next if ignore_model_if&.call(klass)
-          next unless RbsRails::ActiveRecord.generatable?(klass)
-
-          original_path, _line = Object.const_source_location(klass.name) rescue nil
-
-          rbs_relative_path = if original_path && Pathname.new(original_path).fnmatch?("#{Rails.root}/**")
-                                Pathname.new(original_path)
-                                        .relative_path_from(Rails.root)
-                                        .sub_ext('.rbs')
-                              else
-                                "app/models/#{klass.name.underscore}.rbs"
-                              end
-
-          path = signature_root_dir / rbs_relative_path
-          path.dirname.mkpath
-
-          sig = RbsRails::ActiveRecord.class_to_rbs(klass, dependencies: dep_builder.deps)
-          path.write sig
-          dep_builder.done << klass.name
-        rescue => e
-          puts "Error generating RBS for #{klass.name} model"
-          raise e
-        end
-
-        if dep_rbs = dep_builder.build
-          signature_root_dir.join('model_dependencies.rbs').write(dep_rbs)
-        end
+        sh "rbs_rails", "models", "--signature-root-dir=#{signature_root_dir}"
       end
     end
 
     def def_generate_rbs_for_path_helpers #: void
       desc 'Generate RBS files for path helpers'
-      task("#{name}:generate_rbs_for_path_helpers": [:"#{name}:prepare", :environment]) do
-        require 'rbs_rails'
-
-        out_path = signature_root_dir.join 'path_helpers.rbs'
-        rbs = RbsRails::PathHelpers.generate
-        out_path.write rbs
+      task :"#{name}:generate_rbs_for_path_helpers" do
+        sh "rbs_rails", "path_helpers", "--signature-root-dir=#{signature_root_dir}"
       end
     end
 
     private def signature_root_dir #: Pathname
-      Pathname(@signature_root_dir).tap do |dir|
-        dir.mkpath
-      end
+      Pathname(@signature_root_dir)
     end
   end
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -125,6 +125,10 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: dbm
+  version: '0'
+  source:
+    type: stdlib
 - name: delegate
   version: '0'
   source:
@@ -138,6 +142,10 @@ gems:
   source:
     type: stdlib
 - name: fileutils
+  version: '0'
+  source:
+    type: stdlib
+- name: forwardable
   version: '0'
   source:
     type: stdlib
@@ -230,6 +238,14 @@ gems:
   source:
     type: stdlib
 - name: pathname
+  version: '0'
+  source:
+    type: stdlib
+- name: pstore
+  version: '0'
+  source:
+    type: stdlib
+- name: psych
   version: '0'
   source:
     type: stdlib

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -32,3 +32,4 @@ gems:
   - name: json
   - name: optparse
   - name: tsort
+  - name: forwardable

--- a/sig/rbs_rails/cli.rbs
+++ b/sig/rbs_rails/cli.rbs
@@ -1,0 +1,30 @@
+# Generated from lib/rbs_rails/cli.rb with RBS::Inline
+
+module RbsRails
+  class CLI
+    attr_reader options: Hash[Symbol, untyped]
+
+    def initialize: () -> void
+
+    # @rbs argv: Array[String]
+    def run: (Array[String] argv) -> Integer
+
+    private
+
+    def load_application: () -> void
+
+    def install_hooks: () -> void
+
+    def generate_models: () -> void
+
+    # @rbs klass: singleton(ActiveRecord::Base)
+    # @rbs dep_builder: DependencyBuilder
+    def generate_single_model: (singleton(ActiveRecord::Base) klass, DependencyBuilder dep_builder) -> bool
+
+    def generate_path_helpers: () -> void
+
+    def create_option_parser: () -> OptionParser
+
+    def signature_root_dir: () -> Pathname
+  end
+end

--- a/sig/rbs_rails/cli.rbs
+++ b/sig/rbs_rails/cli.rbs
@@ -1,15 +1,20 @@
 # Generated from lib/rbs_rails/cli.rb with RBS::Inline
 
 module RbsRails
-  class CLI
-    attr_reader options: Hash[Symbol, untyped]
+  # @rbs &block: (CLI::Configuration) -> void
+  def self.configure: () { (CLI::Configuration) -> void } -> void
 
-    def initialize: () -> void
+  class CLI
+    attr_reader config_file: String?
 
     # @rbs argv: Array[String]
     def run: (Array[String] argv) -> Integer
 
     private
+
+    def config: () -> Configuration
+
+    def load_config: () -> void
 
     def load_application: () -> void
 
@@ -24,7 +29,5 @@ module RbsRails
     def generate_path_helpers: () -> void
 
     def create_option_parser: () -> OptionParser
-
-    def signature_root_dir: () -> Pathname
   end
 end

--- a/sig/rbs_rails/cli/configuration.rbs
+++ b/sig/rbs_rails/cli/configuration.rbs
@@ -1,0 +1,35 @@
+# Generated from lib/rbs_rails/cli/configuration.rb with RBS::Inline
+
+module RbsRails
+  class CLI
+    class Configuration
+      include Singleton
+
+      def self.instance: () -> Configuration
+
+      def self.configure: () { (Configuration) -> void } -> void
+
+      extend Forwardable
+
+      @signature_root_dir: Pathname?
+
+      @ignore_model_if: (^(singleton(ActiveRecord::Base)) -> bool)?
+
+      def initialize: () -> void
+
+      # @rbs &block: (Configuration) -> void
+      def configure: () { (Configuration) -> void } -> void
+
+      def signature_root_dir: () -> Pathname
+
+      # @rbs dir: String | Pathname
+      def signature_root_dir=: (String | Pathname dir) -> Pathname
+
+      # @rbs &block: (singleton(ActiveRecord::Base)) -> bool
+      def ignore_model_if: () { (singleton(ActiveRecord::Base)) -> bool } -> void
+
+      # @rbs klass: singleton(ActiveRecord::Base)
+      def ignored_model?: (singleton(ActiveRecord::Base) klass) -> bool
+    end
+  end
+end

--- a/sig/rbs_rails/rake_task.rbs
+++ b/sig/rbs_rails/rake_task.rbs
@@ -10,7 +10,7 @@ module RbsRails
 
     attr_accessor name: Symbol
 
-    attr_writer signature_root_dir: Pathname
+    attr_writer signature_root_dir: Pathname?
 
     # @rbs name: ::Symbol
     # @rbs &block: (RbsRails::RakeTask) -> void
@@ -22,6 +22,6 @@ module RbsRails
 
     def def_generate_rbs_for_path_helpers: () -> void
 
-    private def signature_root_dir: () -> Pathname
+    private def signature_root_dir: () -> Pathname?
   end
 end

--- a/sig/rbs_rails/rake_task.rbs
+++ b/sig/rbs_rails/rake_task.rbs
@@ -18,8 +18,6 @@ module RbsRails
 
     def def_all: () -> void
 
-    def def_prepare: () -> untyped
-
     def def_generate_rbs_for_models: () -> void
 
     def def_generate_rbs_for_path_helpers: () -> void

--- a/test/app/app/models/article.rb
+++ b/test/app/app/models/article.rb
@@ -1,0 +1,2 @@
+class Article < ApplicationRecord  # steep:ignore UnknownConstant
+end

--- a/test/app/config/rbs_rails.rb
+++ b/test/app/config/rbs_rails.rb
@@ -1,0 +1,6 @@
+RbsRails.configure do |config|
+  config.ignore_model_if do |klass|
+    # klass.name == "User"
+    false
+  end
+end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -36,6 +36,15 @@ class ActiveRecordTest < Minitest::Test
     assert_equal expect_path.read, rbs_path.read
   end
 
+  def test_article_model_rbs_is_skipped
+    clean_test_signatures
+
+    setup!
+
+    rbs_path = app_dir.join('sig/rbs_rails/app/models/article.rbs')
+    refute rbs_path.exist?
+  end
+
   def test_external_library_model_rbs_generation
     clean_test_signatures
 

--- a/test/rbs_rails/cli/configuration_test.rb
+++ b/test/rbs_rails/cli/configuration_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+require 'active_record'
+require 'rbs_rails/cli'
+require_relative "../../app/config/application"
+
+class ConfigurationTest < Minitest::Test
+  class User < ActiveRecord::Base
+  end
+
+  class Blog < ActiveRecord::Base
+  end
+
+  def setup
+    RbsRails::CLI::Configuration.instance.send(:initialize)
+  end
+
+  def teardown
+    RbsRails::CLI::Configuration.instance.send(:initialize)
+  end
+
+  def test_singleton_behavior
+    config1 = RbsRails::CLI::Configuration.instance
+    config2 = RbsRails::CLI::Configuration.instance
+
+    assert_same config1, config2
+  end
+
+  def test_default_signature_root_dir
+    config = RbsRails::CLI::Configuration.instance
+    expected = Rails.root.join("sig/rbs_rails")
+
+    assert_equal expected, config.signature_root_dir
+  end
+
+  def test_signature_root_dir_with_string
+    path = "path/to/sig"
+
+    RbsRails.configure do |config|
+      config.signature_root_dir = path
+    end
+
+    config = RbsRails::CLI::Configuration.instance
+    assert_equal Pathname.new(path), config.signature_root_dir
+  end
+
+  def test_signature_root_dir_with_pathname
+    path = Pathname.new("path/to/sig")
+
+    RbsRails.configure do |config|
+      config.signature_root_dir = path
+    end
+
+    config = RbsRails::CLI::Configuration.instance
+    assert_equal path, config.signature_root_dir
+  end
+
+  def test_default_ignored_model
+    config = RbsRails::CLI::Configuration.instance
+
+    refute config.ignored_model?(User)
+  end
+
+  def test_ignored_model_with_user_defined_block
+    RbsRails.configure do |config|
+      config.ignore_model_if do |klass|
+        klass.name == "ConfigurationTest::User"
+      end
+    end
+
+    config = RbsRails::CLI::Configuration.instance
+
+    assert config.ignored_model?(User)
+    refute config.ignored_model?(Blog)
+  end
+end


### PR DESCRIPTION
https://github.com/pocke/rbs_rails/pull/296 added `rbs_rails:prepare` task to install inspector modules for Active Record models.  It is required to run before loading Rails application.  It is an incompatible change and hard to understand for users.

To avoid this, this introduces a new command `rbs_rails` to extract types from Rails app in the independent process with Rake.  It allows to install inspectors before loading Rails application easily.

~Note: Sadly, the new command does not support the `ignore_model_if` option.~

I added .rbs_rails.rb to configure our new CLI, and it supports configuring `ignore_model_if` option.