### PR TITLE
test: Share build results across tests to reduce build times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'rbs', '>= 3'
 gem 'rbs-inline', require: false
 gem 'steep', '>= 1.4'
 gem 'minitest'
+gem 'minitest-hooks'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,8 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (5.25.5)
+    minitest-hooks (1.5.2)
+      minitest (> 5.3)
     mutex_m (0.3.0)
     net-imap (0.5.7)
       date
@@ -232,6 +234,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest
+  minitest-hooks
   rails (>= 7.0)
   rake (~> 13.0)
   rbs (>= 3)

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -1,20 +1,19 @@
 require 'test_helper'
 
 class ActiveRecordTest < Minitest::Test
-  def test_type_check
+  include Minitest::Hooks
+
+  def before_all
     clean_test_signatures
 
     setup!
+  end
 
-    dir = app_dir
-    sh!('steep', 'check', chdir: dir)
+  def test_type_check
+    sh!('steep', 'check', chdir: app_dir)
   end
 
   def test_user_model_rbs_snapshot
-    clean_test_signatures
-
-    setup!
-
     rbs_path = app_dir.join('sig/rbs_rails/app/models/user.rbs')
     expect_path = expectations_dir / 'user.rbs'
     # Code to re-generate the expectation files
@@ -24,10 +23,6 @@ class ActiveRecordTest < Minitest::Test
   end
 
   def test_blog_model_rbs_snapshot
-    clean_test_signatures
-
-    setup!
-
     rbs_path = app_dir.join('sig/rbs_rails/packs/blogs/app/models/blog.rbs')
     expect_path = expectations_dir / 'blog.rbs'
     # Code to re-generate the expectation files
@@ -37,19 +32,11 @@ class ActiveRecordTest < Minitest::Test
   end
 
   def test_article_model_rbs_is_skipped
-    clean_test_signatures
-
-    setup!
-
     rbs_path = app_dir.join('sig/rbs_rails/app/models/article.rbs')
     refute rbs_path.exist?
   end
 
   def test_external_library_model_rbs_generation
-    clean_test_signatures
-
-    setup!
-
     rbs_path = app_dir.join('sig/rbs_rails/app/models/audited/audit.rbs')
     expect_path = expectations_dir / 'audited_audit.rbs'
     # Code to re-generate the expectation files

--- a/test/rbs_rails/path_helper_test.rb
+++ b/test/rbs_rails/path_helper_test.rb
@@ -1,20 +1,19 @@
 require 'test_helper'
 
 class PathHelperTest < Minitest::Test
-  def test_type_check
+  include Minitest::Hooks
+
+  def before_all
     clean_test_signatures
 
     setup!
+  end
 
-    dir = app_dir
-    sh!('steep', 'check', chdir: dir)
+  def test_type_check
+    sh!('steep', 'check', chdir: app_dir)
   end
 
   def test_user_model_rbs_snapshot
-    clean_test_signatures
-
-    setup!
-
     rbs_path = app_dir.join('sig/rbs_rails/path_helpers.rbs')
     expect_path = expectations_dir / 'path_helpers.rbs'
     # Code to re-generate the expectation files

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'minitest'
 require 'minitest/autorun'
+require 'minitest/hooks'
 
 require 'pathname'
 require 'rbs_rails'


### PR DESCRIPTION
So far, our testcases build RBS signatures from scratch every time.  It is slow and unnecessary.

This introduces a mechanism to share the built signatures across tests.

Before:

```
Finished in 99.189478s, 0.2016 runs/s, 0.1815 assertions/s.

20 runs, 18 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
Finished in 25.321047s, 0.7899 runs/s, 0.7109 assertions/s.

20 runs, 18 assertions, 0 failures, 0 errors, 0 skips
```