### PR TITLE
Integrate model_dependencies.rbs to each model signatures

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -10,23 +10,23 @@ module RbsRails
 
     # @rbs klass: untyped
     # @rbs dependencies: Array[String]
-    def self.class_to_rbs(klass, dependencies: []) #: untyped
-      Generator.new(klass, dependencies: dependencies).generate
+    def self.class_to_rbs(klass) #: untyped
+      Generator.new(klass).generate
     end
 
     class Generator
       IGNORED_ENUM_KEYS = %i[_prefix _suffix _default _scopes] #: Array[Symbol]
 
       # @rbs @parse_model_file: nil | Parser::AST::Node
-      # @rbs @dependencies: Array[String]
       # @rbs @enum_definitions: Array[Hash[Symbol, untyped]]
       # @rbs @klass_name: String
 
+      attr_reader :dependencies #: DependencyBuilder
+
       # @rbs klass: singleton(ActiveRecord::Base) & Enum
-      # @rbs dependencies: Array[String]
-      def initialize(klass, dependencies:) #: untyped
+      def initialize(klass) #: untyped
         @klass = klass
-        @dependencies = dependencies
+        @dependencies = DependencyBuilder.new
         @klass_name = Util.module_name(klass, abs: false)
 
         namespaces = klass_name(abs: false).split('::').tap{ |names| names.pop }
@@ -62,6 +62,8 @@ module RbsRails
           #{collection_proxy_decl}
 
           #{footer}
+
+          #{dependencies.build}
         RBS
       end
 

--- a/lib/rbs_rails/dependency_builder.rb
+++ b/lib/rbs_rails/dependency_builder.rb
@@ -19,6 +19,11 @@ module RbsRails
       ])
     end
 
+    # @rbs name: String
+    def <<(name) #: Array[String]
+      deps << name
+    end
+
     def build #: String | nil
       dep_rbs = +""
       deps.uniq!

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -7,7 +7,7 @@ module RbsRails
 
     # @rbs klass: untyped
     # @rbs dependencies: Array[String]
-    def self.class_to_rbs: (untyped klass, ?dependencies: Array[String]) -> untyped
+    def self.class_to_rbs: (untyped klass) -> untyped
 
     class Generator
       IGNORED_ENUM_KEYS: Array[Symbol]
@@ -16,13 +16,12 @@ module RbsRails
 
       @enum_definitions: Array[Hash[Symbol, untyped]]
 
-      @dependencies: Array[String]
-
       @parse_model_file: nil | Parser::AST::Node
 
+      attr_reader dependencies: DependencyBuilder
+
       # @rbs klass: singleton(ActiveRecord::Base) & Enum
-      # @rbs dependencies: Array[String]
-      def initialize: (singleton(ActiveRecord::Base) & Enum klass, dependencies: Array[String]) -> untyped
+      def initialize: (singleton(ActiveRecord::Base) & Enum klass) -> untyped
 
       def generate: () -> String
 

--- a/sig/rbs_rails/cli.rbs
+++ b/sig/rbs_rails/cli.rbs
@@ -26,8 +26,7 @@ module RbsRails
     def check_db_migrations!: () -> void
 
     # @rbs klass: singleton(ActiveRecord::Base)
-    # @rbs dep_builder: DependencyBuilder
-    def generate_single_model: (singleton(ActiveRecord::Base) klass, DependencyBuilder dep_builder) -> bool
+    def generate_single_model: (singleton(ActiveRecord::Base) klass) -> bool
 
     def generate_path_helpers: () -> void
 

--- a/sig/rbs_rails/dependency_builder.rbs
+++ b/sig/rbs_rails/dependency_builder.rbs
@@ -8,6 +8,9 @@ module RbsRails
 
     def initialize: () -> void
 
+    # @rbs name: String
+    def <<: (String name) -> Array[String]
+
     def build: () -> (String | nil)
 
     private def shift: () -> (String | nil)

--- a/test/expectations/audited_audit.rbs
+++ b/test/expectations/audited_audit.rbs
@@ -721,3 +721,6 @@ module ::Audited
     end
   end
 end
+
+module ::Audited
+end

--- a/test/expectations/blog.rbs
+++ b/test/expectations/blog.rbs
@@ -328,3 +328,10 @@ class ::Blog < ::ApplicationRecord
     def prepend: (*::Blog | ::Array[::Blog]) -> self
   end
 end
+
+class ::ApplicationRecord < ::ActiveRecord::Base
+end
+class ::User < ::ApplicationRecord
+end
+class ::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+end

--- a/test/expectations/group.rbs
+++ b/test/expectations/group.rbs
@@ -214,3 +214,12 @@ class ::Group < ::ApplicationRecord
     def prepend: (*::Group | ::Array[::Group]) -> self
   end
 end
+
+class ::ApplicationRecord < ::ActiveRecord::Base
+end
+class ::User < ::ApplicationRecord
+end
+class ::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+end
+class ::Thumbnail < ::ApplicationRecord
+end

--- a/test/expectations/model_dependencies.rbs
+++ b/test/expectations/model_dependencies.rbs
@@ -1,8 +1,0 @@
-class ::ApplicationRecord < ::ActiveRecord::Base
-end
-module ::Audited
-end
-class ::User::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-end
-class ::Blog::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
-end

--- a/test/expectations/thumbnail.rbs
+++ b/test/expectations/thumbnail.rbs
@@ -249,3 +249,8 @@ class ::Thumbnail < ::ApplicationRecord
     def prepend: (*::Thumbnail | ::Array[::Thumbnail]) -> self
   end
 end
+
+class ::ApplicationRecord < ::ActiveRecord::Base
+end
+class ::Blog < ::ApplicationRecord
+end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -692,3 +692,12 @@ class ::User < ::ApplicationRecord
     def prepend: (*::User | ::Array[::User]) -> self
   end
 end
+
+class ::ApplicationRecord < ::ActiveRecord::Base
+end
+class ::Blog < ::ApplicationRecord
+end
+class ::Blog::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
+end
+class ::Group < ::ApplicationRecord
+end

--- a/test/rbs_rails/active_record_test.rb
+++ b/test/rbs_rails/active_record_test.rb
@@ -71,15 +71,6 @@ class ActiveRecordTest < Minitest::Test
     assert_equal expect_path.read, rbs_path.read
   end
 
-  def test_model_dependencies
-    rbs_path = app_dir.join('sig/rbs_rails/model_dependencies.rbs')
-    expect_path = expectations_dir / 'model_dependencies.rbs'
-    # Code to re-generate the expectation files
-    # expect_path.write rbs_path.read
-
-    assert_equal expect_path.read, rbs_path.read
-  end
-
   def test_check_db_migrations
     Bundler.with_unbundled_env do
       begin


### PR DESCRIPTION
As a preparation for LSP server, this integrates model_dependencies.rbs
to each model signatures.

With this change, the signature of dependencies will be separated to the
each RBS file of the model.  It allows to rbs_rails to generate
signatures for models one by one, not only the whole of application.  It
also helps the LSP server generate signatures on the fly.

Note: this contains https://github.com/pocke/rbs_rails/pull/344 and https://github.com/pocke/rbs_rails/pull/337.