### PR TITLE
#325/support alias attribute in enum definitions

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -379,7 +379,8 @@ module RbsRails
         # @type var methods: Array[String]
         methods = []
         klass.enum_definitions.map(&:first).uniq.each do |name|
-          class_name = sql_type_to_class(klass.columns_hash[name.to_s].type)
+          column = klass.columns_hash[name.to_s] || klass.columns_hash[klass.attribute_aliases[name.to_s]]
+          class_name = sql_type_to_class(column.type)
           methods << "def #{singleton ? 'self.' : ''}#{name.to_s.pluralize}: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, #{class_name}]"
         end
         klass.enum_definitions.each do |_, method_name|

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   alias_attribute :alias_name, :name
+  alias_attribute :alias_role, :role
+
   scope :all_kind_args, -> (type, m = 1, n = 1, *rest, x, k: 1,**untyped, &blk)  { all }
   scope :no_arg, -> ()  { all }
 
@@ -13,4 +15,5 @@ class User < ApplicationRecord
   has_one_attached :avatar
 
   enum :status, [:temporary, :accepted], default: :temporary
+  enum :alias_role, [:member, :manager], default: :member
 end

--- a/test/app/db/migrate/20250902022119_add_role_to_users.rb
+++ b/test/app/db/migrate/20250902022119_add_role_to_users.rb
@@ -1,0 +1,6 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0 # member
+    change_column_default :users, :role, from: 0, to: nil
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_24_104302) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_02_022119) do
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_24_104302) do
     t.string "family_tree"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", null: false
   end
 
 end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -363,6 +363,46 @@ class ::User < ::ApplicationRecord
     def updated_at_before_type_cast: () -> ::Time
 
     def updated_at_for_database: () -> ::Time
+
+    def role: () -> ::Integer
+
+    def role=: (::Integer) -> ::Integer
+
+    def role?: () -> bool
+
+    def role_changed?: () -> bool
+
+    def role_change: () -> [ ::Integer?, ::Integer? ]
+
+    def role_will_change!: () -> void
+
+    def role_was: () -> ::Integer?
+
+    def role_previously_changed?: () -> bool
+
+    def role_previous_change: () -> ::Array[::Integer?]?
+
+    def role_previously_was: () -> ::Integer?
+
+    def role_before_last_save: () -> ::Integer?
+
+    def role_change_to_be_saved: () -> ::Array[::Integer?]?
+
+    def role_in_database: () -> ::Integer?
+
+    def saved_change_to_role: () -> ::Array[::Integer?]?
+
+    def saved_change_to_role?: () -> bool
+
+    def will_save_change_to_role?: () -> bool
+
+    def restore_role!: () -> void
+
+    def clear_role_change: () -> void
+
+    def role_before_type_cast: () -> ::Integer
+
+    def role_for_database: () -> ::Integer
   end
   include ::User::GeneratedAttributeMethods
   module ::User::GeneratedAliasAttributeMethods
@@ -407,6 +447,46 @@ class ::User < ::ApplicationRecord
     alias alias_name_before_type_cast name_before_type_cast
 
     alias alias_name_for_database name_for_database
+
+    alias alias_role role
+
+    alias alias_role= role=
+
+    alias alias_role? role?
+
+    alias alias_role_changed? role_changed?
+
+    alias alias_role_change role_change
+
+    alias alias_role_will_change! role_will_change!
+
+    alias alias_role_was role_was
+
+    alias alias_role_previously_changed? role_previously_changed?
+
+    alias alias_role_previous_change role_previous_change
+
+    alias alias_role_previously_was role_previously_was
+
+    alias alias_role_before_last_save role_before_last_save
+
+    alias alias_role_change_to_be_saved role_change_to_be_saved
+
+    alias alias_role_in_database role_in_database
+
+    alias saved_change_to_alias_role saved_change_to_role
+
+    alias saved_change_to_alias_role? saved_change_to_role?
+
+    alias will_save_change_to_alias_role? will_save_change_to_role?
+
+    alias restore_alias_role! restore_role!
+
+    alias clear_alias_role_change clear_role_change
+
+    alias alias_role_before_type_cast role_before_type_cast
+
+    alias alias_role_for_database role_for_database
   end
   include ::User::GeneratedAliasAttributeMethods
 
@@ -455,17 +535,28 @@ class ::User < ::ApplicationRecord
   def temporary?: () -> bool
   def accepted!: () -> bool
   def accepted?: () -> bool
+  def member!: () -> bool
+  def member?: () -> bool
+  def manager!: () -> bool
+  def manager?: () -> bool
   def self.statuses: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
+  def self.alias_roles: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
   def self.temporary: () -> ::User::ActiveRecord_Relation
   def self.not_temporary: () -> ::User::ActiveRecord_Relation
   def self.accepted: () -> ::User::ActiveRecord_Relation
   def self.not_accepted: () -> ::User::ActiveRecord_Relation
+  def self.member: () -> ::User::ActiveRecord_Relation
+  def self.not_member: () -> ::User::ActiveRecord_Relation
+  def self.manager: () -> ::User::ActiveRecord_Relation
+  def self.not_manager: () -> ::User::ActiveRecord_Relation
   def self.all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
   def self.no_arg: () -> ::User::ActiveRecord_Relation
   def self.with_attached_avatar: () -> ::User::ActiveRecord_Relation
 
   module ::User::GeneratedRelationMethods
     def statuses: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
+
+    def alias_roles: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, ::Integer]
 
     def temporary: () -> ::User::ActiveRecord_Relation
 
@@ -474,6 +565,14 @@ class ::User < ::ApplicationRecord
     def accepted: () -> ::User::ActiveRecord_Relation
 
     def not_accepted: () -> ::User::ActiveRecord_Relation
+
+    def member: () -> ::User::ActiveRecord_Relation
+
+    def not_member: () -> ::User::ActiveRecord_Relation
+
+    def manager: () -> ::User::ActiveRecord_Relation
+
+    def not_manager: () -> ::User::ActiveRecord_Relation
 
     def all_kind_args: (untyped type, ?untyped m, ?untyped n, *untyped rest, untyped x, ?k: untyped, **untyped untyped) { (*untyped) -> untyped } -> ::User::ActiveRecord_Relation
 

--- a/test/rbs_rails/enum_test.rb
+++ b/test/rbs_rails/enum_test.rb
@@ -2,6 +2,17 @@ require 'test_helper'
 require 'active_record'
 
 class EnumTest < Minitest::Test
+  def test_rails4_alias_attribute_enum
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      alias_attribute :alias_status, :status
+      enum alias_status: [:temporary, :accepted], _default: :temporary
+    end
+
+    assert_equal [[:alias_status, "temporary"], [:alias_status, "accepted"]], model.enum_definitions
+  end
+
   def test_rails4_array_enum
     model = Class.new(ActiveRecord::Base) do
       extend RbsRails::ActiveRecord::Enum
@@ -94,6 +105,17 @@ class EnumTest < Minitest::Test
                   [:timezone, "America_Chicago"],
                   [:timezone, "America_New_York"]],
                  model.enum_definitions
+  end
+
+  def test_rails7_alias_attribute_enum
+    model = Class.new(ActiveRecord::Base) do
+      extend RbsRails::ActiveRecord::Enum
+
+      alias_attribute :alias_status, :status
+      enum :alias_status, [:temporary, :accepted], default: :temporary
+    end
+
+    assert_equal [[:alias_status, "temporary"], [:alias_status, "accepted"]], model.enum_definitions
   end
 
   def test_rails7_array_enum


### PR DESCRIPTION
Resolve #325

This change modifies the enum definition process to correctly resolve the alias_attributed name to the underlying database column.