### PR TITLE
test: Fix module names in generated RBS files

### DIFF
--- a/test/expectations/audited_audit.rbs
+++ b/test/expectations/audited_audit.rbs
@@ -2,7 +2,7 @@
 
 module ::Audited
   class ::Audited::Audit < ::ActiveRecord::Base
-    extend ::_ActiveRecord_Relation_ClassMethods[::Audited::Audit, ::Audited::Audit::ActiveRecord_Relation, ::Integer]
+    extend ::ActiveRecord::Base::ClassMethods[::Audited::Audit, ::Audited::Audit::ActiveRecord_Relation, ::Integer]
 
     module ::Audited::Audit::GeneratedAttributeMethods
       def id: () -> ::Integer
@@ -656,14 +656,14 @@ module ::Audited
 
     class ::Audited::Audit::ActiveRecord_Relation < ::ActiveRecord::Relation
       include ::Audited::Audit::GeneratedRelationMethods
-      include ::_ActiveRecord_Relation[::Audited::Audit, ::Integer]
+      include ::ActiveRecord::Relation::Methods[::Audited::Audit, ::Integer]
       include ::Enumerable[::Audited::Audit]
     end
 
     class ::Audited::Audit::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
       include ::Enumerable[::Audited::Audit]
       include ::Audited::Audit::GeneratedRelationMethods
-      include ::_ActiveRecord_Relation[::Audited::Audit, ::Integer]
+      include ::ActiveRecord::Relation::Methods[::Audited::Audit, ::Integer]
 
       def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> ::Audited::Audit
                | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[::Audited::Audit]

--- a/test/expectations/blog.rbs
+++ b/test/expectations/blog.rbs
@@ -1,7 +1,7 @@
 # resolve-type-names: false
 
 class ::Blog < ::ApplicationRecord
-  extend ::_ActiveRecord_Relation_ClassMethods[::Blog, ::Blog::ActiveRecord_Relation, ::Integer]
+  extend ::ActiveRecord::Base::ClassMethods[::Blog, ::Blog::ActiveRecord_Relation, ::Integer]
 
   module ::Blog::GeneratedAttributeMethods
     def id: () -> ::Integer
@@ -264,14 +264,14 @@ class ::Blog < ::ApplicationRecord
 
   class ::Blog::ActiveRecord_Relation < ::ActiveRecord::Relation
     include ::Blog::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Blog, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Blog, ::Integer]
     include ::Enumerable[::Blog]
   end
 
   class ::Blog::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
     include ::Enumerable[::Blog]
     include ::Blog::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Blog, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Blog, ::Integer]
 
     def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> ::Blog
              | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[::Blog]

--- a/test/expectations/group.rbs
+++ b/test/expectations/group.rbs
@@ -1,7 +1,7 @@
 # resolve-type-names: false
 
 class ::Group < ::ApplicationRecord
-  extend ::_ActiveRecord_Relation_ClassMethods[::Group, ::Group::ActiveRecord_Relation, ::Integer]
+  extend ::ActiveRecord::Base::ClassMethods[::Group, ::Group::ActiveRecord_Relation, ::Integer]
 
   module ::Group::GeneratedAttributeMethods
     def id: () -> ::Integer
@@ -150,14 +150,14 @@ class ::Group < ::ApplicationRecord
 
   class ::Group::ActiveRecord_Relation < ::ActiveRecord::Relation
     include ::Group::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Group, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Group, ::Integer]
     include ::Enumerable[::Group]
   end
 
   class ::Group::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
     include ::Enumerable[::Group]
     include ::Group::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Group, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Group, ::Integer]
 
     def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> ::Group
              | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[::Group]

--- a/test/expectations/thumbnail.rbs
+++ b/test/expectations/thumbnail.rbs
@@ -1,7 +1,7 @@
 # resolve-type-names: false
 
 class ::Thumbnail < ::ApplicationRecord
-  extend ::_ActiveRecord_Relation_ClassMethods[::Thumbnail, ::Thumbnail::ActiveRecord_Relation, ::Integer]
+  extend ::ActiveRecord::Base::ClassMethods[::Thumbnail, ::Thumbnail::ActiveRecord_Relation, ::Integer]
 
   module ::Thumbnail::GeneratedAttributeMethods
     def id: () -> ::Integer
@@ -185,14 +185,14 @@ class ::Thumbnail < ::ApplicationRecord
 
   class ::Thumbnail::ActiveRecord_Relation < ::ActiveRecord::Relation
     include ::Thumbnail::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Thumbnail, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Thumbnail, ::Integer]
     include ::Enumerable[::Thumbnail]
   end
 
   class ::Thumbnail::ActiveRecord_Associations_CollectionProxy < ::ActiveRecord::Associations::CollectionProxy
     include ::Enumerable[::Thumbnail]
     include ::Thumbnail::GeneratedRelationMethods
-    include ::_ActiveRecord_Relation[::Thumbnail, ::Integer]
+    include ::ActiveRecord::Relation::Methods[::Thumbnail, ::Integer]
 
     def build: (?::ActiveRecord::Associations::CollectionProxy::_EachPair attributes) ?{ () -> untyped } -> ::Thumbnail
              | (::Array[::ActiveRecord::Associations::CollectionProxy::_EachPair] attributes) ?{ () -> untyped } -> ::Array[::Thumbnail]


### PR DESCRIPTION
Since #317, the module names for generated models has been changed. This commit updates the test expectations to follow the new names.