### PR TITLE
active_record: Support `#id_value` alias for `#id` column

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -555,9 +555,12 @@ module RbsRails
       end
 
       private def alias_columns
+        attribute_aliases = klass.attribute_aliases
+        attribute_aliases["id_value"] ||= "id" if klass.attribute_names.include?("id")
+
         mod_sig = +"module #{klass_name}::GeneratedAliasAttributeMethods\n"
         mod_sig << "include #{klass_name}::GeneratedAttributeMethods\n"
-        mod_sig << klass.attribute_aliases.map do |col|
+        mod_sig << attribute_aliases.map do |col|
           sig = <<~EOS
             alias #{col[0]} #{col[1]}
             alias #{col[0]}= #{col[1]}=

--- a/test/expectations/audited_audit.rbs
+++ b/test/expectations/audited_audit.rbs
@@ -608,6 +608,46 @@ module ::Audited
     include ::Audited::Audit::GeneratedAttributeMethods
     module ::Audited::Audit::GeneratedAliasAttributeMethods
       include ::Audited::Audit::GeneratedAttributeMethods
+
+      alias id_value id
+
+      alias id_value= id=
+
+      alias id_value? id?
+
+      alias id_value_changed? id_changed?
+
+      alias id_value_change id_change
+
+      alias id_value_will_change! id_will_change!
+
+      alias id_value_was id_was
+
+      alias id_value_previously_changed? id_previously_changed?
+
+      alias id_value_previous_change id_previous_change
+
+      alias id_value_previously_was id_previously_was
+
+      alias id_value_before_last_save id_before_last_save
+
+      alias id_value_change_to_be_saved id_change_to_be_saved
+
+      alias id_value_in_database id_in_database
+
+      alias saved_change_to_id_value saved_change_to_id
+
+      alias saved_change_to_id_value? saved_change_to_id?
+
+      alias will_save_change_to_id_value? will_save_change_to_id?
+
+      alias restore_id_value! restore_id!
+
+      alias clear_id_value_change clear_id_change
+
+      alias id_value_before_type_cast id_before_type_cast
+
+      alias id_value_for_database id_for_database
     end
     include ::Audited::Audit::GeneratedAliasAttributeMethods
 

--- a/test/expectations/blog.rbs
+++ b/test/expectations/blog.rbs
@@ -247,6 +247,46 @@ class ::Blog < ::ApplicationRecord
   include ::Blog::GeneratedAttributeMethods
   module ::Blog::GeneratedAliasAttributeMethods
     include ::Blog::GeneratedAttributeMethods
+
+    alias id_value id
+
+    alias id_value= id=
+
+    alias id_value? id?
+
+    alias id_value_changed? id_changed?
+
+    alias id_value_change id_change
+
+    alias id_value_will_change! id_will_change!
+
+    alias id_value_was id_was
+
+    alias id_value_previously_changed? id_previously_changed?
+
+    alias id_value_previous_change id_previous_change
+
+    alias id_value_previously_was id_previously_was
+
+    alias id_value_before_last_save id_before_last_save
+
+    alias id_value_change_to_be_saved id_change_to_be_saved
+
+    alias id_value_in_database id_in_database
+
+    alias saved_change_to_id_value saved_change_to_id
+
+    alias saved_change_to_id_value? saved_change_to_id?
+
+    alias will_save_change_to_id_value? will_save_change_to_id?
+
+    alias restore_id_value! restore_id!
+
+    alias clear_id_value_change clear_id_change
+
+    alias id_value_before_type_cast id_before_type_cast
+
+    alias id_value_for_database id_for_database
   end
   include ::Blog::GeneratedAliasAttributeMethods
 

--- a/test/expectations/group.rbs
+++ b/test/expectations/group.rbs
@@ -127,6 +127,46 @@ class ::Group < ::ApplicationRecord
   include ::Group::GeneratedAttributeMethods
   module ::Group::GeneratedAliasAttributeMethods
     include ::Group::GeneratedAttributeMethods
+
+    alias id_value id
+
+    alias id_value= id=
+
+    alias id_value? id?
+
+    alias id_value_changed? id_changed?
+
+    alias id_value_change id_change
+
+    alias id_value_will_change! id_will_change!
+
+    alias id_value_was id_was
+
+    alias id_value_previously_changed? id_previously_changed?
+
+    alias id_value_previous_change id_previous_change
+
+    alias id_value_previously_was id_previously_was
+
+    alias id_value_before_last_save id_before_last_save
+
+    alias id_value_change_to_be_saved id_change_to_be_saved
+
+    alias id_value_in_database id_in_database
+
+    alias saved_change_to_id_value saved_change_to_id
+
+    alias saved_change_to_id_value? saved_change_to_id?
+
+    alias will_save_change_to_id_value? will_save_change_to_id?
+
+    alias restore_id_value! restore_id!
+
+    alias clear_id_value_change clear_id_change
+
+    alias id_value_before_type_cast id_before_type_cast
+
+    alias id_value_for_database id_for_database
   end
   include ::Group::GeneratedAliasAttributeMethods
   def users: () -> ::User::ActiveRecord_Associations_CollectionProxy

--- a/test/expectations/thumbnail.rbs
+++ b/test/expectations/thumbnail.rbs
@@ -167,6 +167,46 @@ class ::Thumbnail < ::ApplicationRecord
   include ::Thumbnail::GeneratedAttributeMethods
   module ::Thumbnail::GeneratedAliasAttributeMethods
     include ::Thumbnail::GeneratedAttributeMethods
+
+    alias id_value id
+
+    alias id_value= id=
+
+    alias id_value? id?
+
+    alias id_value_changed? id_changed?
+
+    alias id_value_change id_change
+
+    alias id_value_will_change! id_will_change!
+
+    alias id_value_was id_was
+
+    alias id_value_previously_changed? id_previously_changed?
+
+    alias id_value_previous_change id_previous_change
+
+    alias id_value_previously_was id_previously_was
+
+    alias id_value_before_last_save id_before_last_save
+
+    alias id_value_change_to_be_saved id_change_to_be_saved
+
+    alias id_value_in_database id_in_database
+
+    alias saved_change_to_id_value saved_change_to_id
+
+    alias saved_change_to_id_value? saved_change_to_id?
+
+    alias will_save_change_to_id_value? will_save_change_to_id?
+
+    alias restore_id_value! restore_id!
+
+    alias clear_id_value_change clear_id_change
+
+    alias id_value_before_type_cast id_before_type_cast
+
+    alias id_value_for_database id_for_database
   end
   include ::Thumbnail::GeneratedAliasAttributeMethods
 

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -447,6 +447,46 @@ class ::User < ::ApplicationRecord
     alias alias_name_before_type_cast name_before_type_cast
 
     alias alias_name_for_database name_for_database
+
+    alias id_value id
+
+    alias id_value= id=
+
+    alias id_value? id?
+
+    alias id_value_changed? id_changed?
+
+    alias id_value_change id_change
+
+    alias id_value_will_change! id_will_change!
+
+    alias id_value_was id_was
+
+    alias id_value_previously_changed? id_previously_changed?
+
+    alias id_value_previous_change id_previous_change
+
+    alias id_value_previously_was id_previously_was
+
+    alias id_value_before_last_save id_before_last_save
+
+    alias id_value_change_to_be_saved id_change_to_be_saved
+
+    alias id_value_in_database id_in_database
+
+    alias saved_change_to_id_value saved_change_to_id
+
+    alias saved_change_to_id_value? saved_change_to_id?
+
+    alias will_save_change_to_id_value? will_save_change_to_id?
+
+    alias restore_id_value! restore_id!
+
+    alias clear_id_value_change clear_id_change
+
+    alias id_value_before_type_cast id_before_type_cast
+
+    alias id_value_for_database id_for_database
   end
   include ::User::GeneratedAliasAttributeMethods
 


### PR DESCRIPTION
Since Rails 7.1, ActiveRecord provides `#id_value` alias for the `#id` column.  It will be defined if the model has `id` column.

Note: The alias definition is not stored in `attribute_aliases`.  It is generated on the instantiation of the model automatically.  Therefore, we need to give special treatment to generate `#id_value` alias like ActiveRecord does.

refs:

- https://github.com/rails/rails/pull/48930
- https://github.com/pocke/rbs_rails/pull/321#issuecomment-3368146461