### PR TITLE
Support type generation for ActiveRecord virtual attributes

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -641,6 +641,45 @@ module RbsRails
         end.join("\n")
         mod_sig << "\nend\n"
         mod_sig << "include #{klass_name}::GeneratedAttributeMethods"
+        va = virtual_attributes
+        mod_sig << "\n#{va}" unless va.empty?
+        mod_sig
+      end
+
+      private def virtual_attributes #: String
+        column_names = klass.columns.map(&:name)
+        names = klass.attribute_names.reject { |name| column_names.include?(name) }
+        return '' if names.empty?
+
+        mod_sig = +"module #{klass_name}::GeneratedAttributeMethods\n"
+        mod_sig << names.map do |name|
+          type = klass.attribute_types[name]
+          class_name = sql_type_to_class(type.type)
+          class_name_opt = (class_name == 'untyped') ? 'untyped' : optional(class_name)
+          sig = <<~EOS
+            def #{name}: () -> #{class_name_opt}
+            def #{name}=: (#{class_name_opt}) -> #{class_name_opt}
+            def #{name}?: () -> bool
+            def #{name}_changed?: (?from: #{class_name_opt}, ?to: #{class_name_opt}) -> bool
+            def #{name}_change: () -> [#{class_name_opt}, #{class_name_opt}]
+            def #{name}_will_change!: () -> void
+            def #{name}_was: () -> #{class_name_opt}
+            def #{name}_previously_changed?: (?from: #{class_name_opt}, ?to: #{class_name_opt}) -> bool
+            def #{name}_previous_change: () -> ::Array[#{class_name_opt}]?
+            def #{name}_previously_was: () -> #{class_name_opt}
+            def #{name}_before_last_save: () -> #{class_name_opt}
+            def #{name}_change_to_be_saved: () -> ::Array[#{class_name_opt}]?
+            def #{name}_in_database: () -> #{class_name_opt}
+            def saved_change_to_#{name}: () -> ::Array[#{class_name_opt}]?
+            def saved_change_to_#{name}?: (?from: #{class_name_opt}, ?to: #{class_name_opt}) -> bool
+            def will_save_change_to_#{name}?: (?from: #{class_name_opt}, ?to: #{class_name_opt}) -> bool
+            def restore_#{name}!: () -> void
+            def clear_#{name}_change: () -> void
+          EOS
+          sig << "\n"
+          sig
+        end.join("\n")
+        mod_sig << "\nend\n"
         mod_sig
       end
 

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -95,6 +95,8 @@ module RbsRails
 
       private def columns: () -> untyped
 
+      private def virtual_attributes: () -> String
+
       private def alias_columns: () -> untyped
 
       # @rbs class_name: String

--- a/test/app/app/models/order.rb
+++ b/test/app/app/models/order.rb
@@ -1,4 +1,7 @@
 class Order < ApplicationRecord
   self.primary_key = [:shop_id, :id]
   has_many :book
+
+  attribute :tax_rate, :float, default: 0.1
+  attribute :gift_message, :string
 end

--- a/test/expectations/order.rbs
+++ b/test/expectations/order.rbs
@@ -205,6 +205,80 @@ class ::Order < ::ApplicationRecord
     def updated_at_for_database: () -> ::Time
   end
   include ::Order::GeneratedAttributeMethods
+  module ::Order::GeneratedAttributeMethods
+    def tax_rate: () -> ::Float?
+
+    def tax_rate=: (::Float?) -> ::Float?
+
+    def tax_rate?: () -> bool
+
+    def tax_rate_changed?: (?from: ::Float?, ?to: ::Float?) -> bool
+
+    def tax_rate_change: () -> [ ::Float?, ::Float? ]
+
+    def tax_rate_will_change!: () -> void
+
+    def tax_rate_was: () -> ::Float?
+
+    def tax_rate_previously_changed?: (?from: ::Float?, ?to: ::Float?) -> bool
+
+    def tax_rate_previous_change: () -> ::Array[::Float?]?
+
+    def tax_rate_previously_was: () -> ::Float?
+
+    def tax_rate_before_last_save: () -> ::Float?
+
+    def tax_rate_change_to_be_saved: () -> ::Array[::Float?]?
+
+    def tax_rate_in_database: () -> ::Float?
+
+    def saved_change_to_tax_rate: () -> ::Array[::Float?]?
+
+    def saved_change_to_tax_rate?: (?from: ::Float?, ?to: ::Float?) -> bool
+
+    def will_save_change_to_tax_rate?: (?from: ::Float?, ?to: ::Float?) -> bool
+
+    def restore_tax_rate!: () -> void
+
+    def clear_tax_rate_change: () -> void
+
+    def gift_message: () -> ::String?
+
+    def gift_message=: (::String?) -> ::String?
+
+    def gift_message?: () -> bool
+
+    def gift_message_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def gift_message_change: () -> [ ::String?, ::String? ]
+
+    def gift_message_will_change!: () -> void
+
+    def gift_message_was: () -> ::String?
+
+    def gift_message_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def gift_message_previous_change: () -> ::Array[::String?]?
+
+    def gift_message_previously_was: () -> ::String?
+
+    def gift_message_before_last_save: () -> ::String?
+
+    def gift_message_change_to_be_saved: () -> ::Array[::String?]?
+
+    def gift_message_in_database: () -> ::String?
+
+    def saved_change_to_gift_message: () -> ::Array[::String?]?
+
+    def saved_change_to_gift_message?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_gift_message?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_gift_message!: () -> void
+
+    def clear_gift_message_change: () -> void
+  end
+
   module ::Order::GeneratedAliasAttributeMethods
     include ::Order::GeneratedAttributeMethods
 


### PR DESCRIPTION
## Summary

Generate RBS type signatures for virtual attributes defined via ActiveRecord's
`attribute` macro (e.g. `attribute :tax_rate, :float`).

Previously, only database-backed columns had type signatures generated.
Virtual attributes were silently skipped, leaving their getter, setter,
predicate, and dirty-tracking methods untyped.

## Changes

- **`lib/rbs_rails/active_record.rb`**: Add `virtual_attributes` private method
  that detects attributes in `attribute_names` not backed by DB columns, and
  generates RBS signatures (getter, setter, `?`, dirty-tracking methods).
  Called from `columns` to reopen `GeneratedAttributeMethods`.
- **`test/app/app/models/order.rb`**: Add two virtual attributes (`tax_rate`
  as `:float`, `gift_message` as `:string`) for testing.
- **`test/expectations/order.rbs`**: Updated snapshot with expected virtual
  attribute signatures.
