### PR TITLE
Add missing association methods for belongs_to and has_one (Rails 7.0+)

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -217,6 +217,7 @@ module RbsRails
             def create_#{a.name}: (?untyped) -> #{type}
             def create_#{a.name}!: (?untyped) -> #{type}
             def reload_#{a.name}: () -> #{type_optional}
+            def reset_#{a.name}: () -> void
           RUBY
         end.join("\n")
       end
@@ -234,6 +235,9 @@ module RbsRails
           methods << "def #{a.name}: () -> #{is_optional ? type_optional : type}"
           methods << "def #{a.name}=: (#{type_optional}) -> #{type_optional}"
           methods << "def reload_#{a.name}: () -> #{type_optional}"
+          methods << "def #{a.name}_changed?: () -> bool"
+          methods << "def #{a.name}_previously_changed?: () -> bool"
+          methods << "def reset_#{a.name}: () -> void"
           if !a.polymorphic?
             methods << "def build_#{a.name}: (?untyped) -> #{type}"
             methods << "def create_#{a.name}: (?untyped) -> #{type}"

--- a/test/expectations/audited_audit.rbs
+++ b/test/expectations/audited_audit.rbs
@@ -654,12 +654,21 @@ module ::Audited
     def auditable: () -> untyped
     def auditable=: (untyped?) -> untyped?
     def reload_auditable: () -> untyped?
+    def auditable_changed?: () -> bool
+    def auditable_previously_changed?: () -> bool
+    def reset_auditable: () -> void
     def user: () -> untyped
     def user=: (untyped?) -> untyped?
     def reload_user: () -> untyped?
+    def user_changed?: () -> bool
+    def user_previously_changed?: () -> bool
+    def reset_user: () -> void
     def associated: () -> untyped
     def associated=: (untyped?) -> untyped?
     def reload_associated: () -> untyped?
+    def associated_changed?: () -> bool
+    def associated_previously_changed?: () -> bool
+    def reset_associated: () -> void
 
     module ::Audited::Audit::GeneratedAssociationMethods
     end

--- a/test/expectations/book.rbs
+++ b/test/expectations/book.rbs
@@ -293,6 +293,9 @@ class ::Book < ::ApplicationRecord
   def order: () -> ::Order
   def order=: (::Order?) -> ::Order?
   def reload_order: () -> ::Order?
+  def order_changed?: () -> bool
+  def order_previously_changed?: () -> bool
+  def reset_order: () -> void
   def build_order: (?untyped) -> ::Order
   def create_order: (?untyped) -> ::Order
   def create_order!: (?untyped) -> ::Order

--- a/test/expectations/delivery_address.rbs
+++ b/test/expectations/delivery_address.rbs
@@ -413,6 +413,9 @@ class ::DeliveryAddress < ::ApplicationRecord
   def user: () -> ::User
   def user=: (::User?) -> ::User?
   def reload_user: () -> ::User?
+  def user_changed?: () -> bool
+  def user_previously_changed?: () -> bool
+  def reset_user: () -> void
   def build_user: (?untyped) -> ::User
   def create_user: (?untyped) -> ::User
   def create_user!: (?untyped) -> ::User

--- a/test/expectations/group.rbs
+++ b/test/expectations/group.rbs
@@ -180,6 +180,7 @@ class ::Group < ::ApplicationRecord
   def create_thumbnail: (?untyped) -> ::Thumbnail
   def create_thumbnail!: (?untyped) -> ::Thumbnail
   def reload_thumbnail: () -> ::Thumbnail?
+  def reset_thumbnail: () -> void
 
   module ::Group::GeneratedAssociationMethods
     def users_attributes=: (Hash[untyped, untyped] | Array[Hash[untyped, untyped]]) -> void

--- a/test/expectations/tag.rbs
+++ b/test/expectations/tag.rbs
@@ -253,6 +253,9 @@ class ::Tag < ::ApplicationRecord
   def project: () -> ::Project
   def project=: (::Project?) -> ::Project?
   def reload_project: () -> ::Project?
+  def project_changed?: () -> bool
+  def project_previously_changed?: () -> bool
+  def reset_project: () -> void
   def build_project: (?untyped) -> ::Project
   def create_project: (?untyped) -> ::Project
   def create_project!: (?untyped) -> ::Project

--- a/test/expectations/thumbnail.rbs
+++ b/test/expectations/thumbnail.rbs
@@ -213,6 +213,9 @@ class ::Thumbnail < ::ApplicationRecord
   def blog: () -> ::Blog
   def blog=: (::Blog?) -> ::Blog?
   def reload_blog: () -> ::Blog?
+  def blog_changed?: () -> bool
+  def blog_previously_changed?: () -> bool
+  def reset_blog: () -> void
   def build_blog: (?untyped) -> ::Blog
   def create_blog: (?untyped) -> ::Blog
   def create_blog!: (?untyped) -> ::Blog

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -623,15 +623,20 @@ class ::User < ::ApplicationRecord
   def create_avatar_attachment: (?untyped) -> ::ActiveStorage::Attachment
   def create_avatar_attachment!: (?untyped) -> ::ActiveStorage::Attachment
   def reload_avatar_attachment: () -> ::ActiveStorage::Attachment?
+  def reset_avatar_attachment: () -> void
   def avatar_blob: () -> ::ActiveStorage::Blob?
   def avatar_blob=: (::ActiveStorage::Blob?) -> ::ActiveStorage::Blob?
   def build_avatar_blob: (?untyped) -> ::ActiveStorage::Blob
   def create_avatar_blob: (?untyped) -> ::ActiveStorage::Blob
   def create_avatar_blob!: (?untyped) -> ::ActiveStorage::Blob
   def reload_avatar_blob: () -> ::ActiveStorage::Blob?
+  def reset_avatar_blob: () -> void
   def group: () -> ::Group
   def group=: (::Group?) -> ::Group?
   def reload_group: () -> ::Group?
+  def group_changed?: () -> bool
+  def group_previously_changed?: () -> bool
+  def reset_group: () -> void
   def build_group: (?untyped) -> ::Group
   def create_group: (?untyped) -> ::Group
   def create_group!: (?untyped) -> ::Group


### PR DESCRIPTION
## Summary
Generate RBS type signatures for `belongs_to` association methods (`changed?`, `previously_changed?`, `reset_`) and `has_one` association method (`reset_`) that were added in Rails 7.0 and 7.1.

## Problem
Rails 7.0+ added `#{association}_changed?` and `#{association}_previously_changed?` for `belongs_to` associations ([rails/rails#42751](https://github.com/rails/rails/pull/42751)), and Rails 7.1+ added `reset_#{association}` for both `belongs_to` and `has_one` associations ([rails/rails#46165](https://github.com/rails/rails/pull/46165)). rbs_rails did not generate type signatures for these methods.

## Changes
- **`lib/rbs_rails/active_record.rb`**: Added 3 new method signatures to `belongs_to` (`changed?`, `previously_changed?`, `reset_`) and 1 to `has_one` (`reset_`). All are generated for polymorphic associations as well, matching Rails behavior.
- **`test/expectations/*.rbs`**: Updated 7 expectation files (`user.rbs`, `book.rbs`, `delivery_address.rbs`, `thumbnail.rbs`, `group.rbs`, `tag.rbs`, `audited_audit.rbs`) with the new method signatures.

## References
- https://github.com/rails/rails/pull/42751
- https://github.com/rails/rails/pull/46165

Closes #286