### PR TITLE
Re-implement CLI core with Thor for future subcommand extensibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       parser
       prism
       rbs (>= 1)
+      thor (>= 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/exe/rbs_rails
+++ b/exe/rbs_rails
@@ -3,4 +3,9 @@
 require "rbs_rails"
 require "rbs_rails/cli"
 
-exit RbsRails::CLI.new().run(ARGV)
+begin
+  RbsRails::CLI.start(ARGV)
+rescue StandardError => e
+  $stderr.puts "Error: #{e.message}"
+  exit 1
+end

--- a/lib/rbs_rails/cli.rb
+++ b/lib/rbs_rails/cli.rb
@@ -1,4 +1,4 @@
-require "optparse"
+require "thor"
 require "rbs_rails/cli/configuration"
 
 module RbsRails
@@ -7,62 +7,58 @@ module RbsRails
     CLI::Configuration.configure(&block)
   end
 
-  class CLI
-    attr_reader :config_file #: String?
+  class CLI < Thor
+    class_option :signature_root_dir, type: :string, banner: "DIR",
+                 desc: "Specify the root directory for RBS signatures"
+    class_option :config, type: :string, banner: "FILE",
+                 desc: "Load configuration from FILE"
 
-    # @rbs argv: Array[String]
-    def run(argv) #: Integer
-      parser = create_option_parser
+    desc "all", "Generate all RBS files"
+    def all #: void
+      apply_options
+      load_application
+      load_config
+      generate_models
+      generate_path_helpers
+    end
 
-      begin
-        args = parser.parse(argv)
-        subcommand = args.shift || "help"
+    desc "models", "Generate RBS files for models"
+    def models #: void
+      apply_options
+      load_application
+      load_config
+      generate_models
+    end
 
-        case subcommand
-        when "help"
-          $stdout.puts parser.help
-          0
-        when "version"
-          $stdout.puts "rbs_rails #{RbsRails::VERSION}"
-          0
-        when "all"
-          load_application
-          load_config
-          generate_models
-          generate_path_helpers
-          0
-        when "models"
-          load_application
-          load_config
-          generate_models
-          0
-        when "path_helpers"
-          load_application
-          load_config
-          generate_path_helpers
-          0
-        else
-          $stdout.puts "Unknown command: #{subcommand}"
-          $stdout.puts parser.help
-          1
-        end
-      rescue OptionParser::InvalidOption => e
-        $stderr.puts "Error: #{e.message}"
-        $stdout.puts parser.help
-        1
-      end
-    rescue StandardError => e
-      $stderr.puts "Error: #{e.message}"
-      1
+    desc "path_helpers", "Generate RBS for Rails path helpers"
+    def path_helpers #: void
+      apply_options
+      load_application
+      load_config
+      generate_path_helpers
+    end
+
+    desc "version", "Show version"
+    def version #: void
+      puts "rbs_rails #{RbsRails::VERSION}"
+    end
+
+    def self.exit_on_failure? #: bool
+      true
     end
 
     private
 
-    def config #: Configuration
+    def apply_options #: void
+      rbs_config.signature_root_dir = Pathname.new(options[:signature_root_dir]) if options[:signature_root_dir]
+    end
+
+    def rbs_config #: Configuration
       Configuration.instance
     end
 
     def load_config #: void
+      config_file = options[:config]
       if config_file
         load config_file
       else
@@ -103,7 +99,7 @@ module RbsRails
 
     # Raise an error if database is not migrated to the latest version
     def check_db_migrations! #: void
-      return unless config.check_db_migrations
+      return unless rbs_config.check_db_migrations
 
       if ::ActiveRecord::Migration.respond_to? :check_all_pending!
         # Rails 7.1 or later
@@ -115,7 +111,7 @@ module RbsRails
 
     # @rbs klass: singleton(ActiveRecord::Base)
     def generate_single_model(klass) #: bool
-      return false if config.ignored_model?(klass)
+      return false if rbs_config.ignored_model?(klass)
       return false unless RbsRails::ActiveRecord.generatable?(klass)
 
       original_path, _line = Object.const_source_location(klass.name) rescue nil
@@ -128,7 +124,7 @@ module RbsRails
                             "app/models/#{klass.name.underscore}.rbs"
                           end
 
-      path = config.signature_root_dir / rbs_relative_path
+      path = rbs_config.signature_root_dir / rbs_relative_path
       path.dirname.mkpath
 
       sig = RbsRails::ActiveRecord.class_to_rbs(klass)
@@ -138,36 +134,11 @@ module RbsRails
     end
 
     def generate_path_helpers #: void
-      path = config.signature_root_dir.join 'path_helpers.rbs'
+      path = rbs_config.signature_root_dir.join 'path_helpers.rbs'
       path.dirname.mkpath
 
       sig = RbsRails::PathHelpers.generate
       Util::FileWriter.new(path).write sig
-    end
-
-    def create_option_parser #: OptionParser
-      OptionParser.new do |opts|
-        opts.banner = <<~BANNER
-          Usage: rbs_rails [command] [options]
-
-          Commands:
-                  help           Show this help message
-                  version        Show version
-                  all            Generate all RBS files
-                  models         Generate RBS files for models
-                  path_helpers   Generate RBS for Rails path helpers
-
-          Options:
-        BANNER
-
-        opts.on("--signature-root-dir=DIR", "Specify the root directory for RBS signatures") do |dir|
-          config.signature_root_dir = Pathname.new(dir)
-        end
-
-        opts.on("--config=FILE", "Load configuration from FILE") do |file|
-          @config_file = file
-        end
-      end
     end
   end
 end

--- a/lib/rbs_rails/cli/configuration.rb
+++ b/lib/rbs_rails/cli/configuration.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 require 'singleton'
 
 module RbsRails
-  class CLI
+  class CLI < Thor
     class Configuration
       include Singleton
 

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionmailer
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionpack
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actiontext
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: actionview
@@ -38,7 +38,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activejob
@@ -46,7 +46,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activemodel
@@ -54,7 +54,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activerecord
@@ -62,7 +62,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activestorage
@@ -70,7 +70,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: activesupport
@@ -78,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -86,7 +86,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -98,23 +98,27 @@ gems:
   source:
     type: stdlib
 - name: bigdecimal
-  version: '3.1'
+  version: '4.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: cgi
-  version: '0'
+  version: '0.5'
   source:
-    type: stdlib
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: concurrent-ruby
   version: '1.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -122,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -154,7 +158,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -162,7 +166,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: io-console
@@ -178,7 +182,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mail
@@ -186,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: marcel
@@ -194,7 +198,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: mini_mime
@@ -202,7 +206,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: minitest
@@ -210,7 +214,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -226,7 +230,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: nokogiri
@@ -234,7 +238,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: openssl
@@ -250,7 +254,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
@@ -266,7 +270,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-dom-testing
@@ -274,7 +278,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rails-html-sanitizer
@@ -282,7 +286,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: railties
@@ -290,7 +294,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -298,7 +302,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
@@ -334,7 +338,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: time
@@ -354,7 +358,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: ea8449cbfd146213cc46b6e67e747ae61fefed66
+    revision: 81fa8bd0617286078617a62b6a3229cebfd4af23
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -14,6 +14,5 @@ gems:
   - name: logger
   - name: pathname
   - name: json
-  - name: optparse
   - name: tsort
   - name: forwardable

--- a/rbs_rails.gemspec
+++ b/rbs_rails.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'parser'
   spec.add_runtime_dependency 'prism'
   spec.add_runtime_dependency 'rbs', '>= 1'
+  spec.add_runtime_dependency 'thor', '>= 1.0'
 end

--- a/sig/rbs_rails/cli.rbs
+++ b/sig/rbs_rails/cli.rbs
@@ -4,15 +4,22 @@ module RbsRails
   # @rbs &block: (CLI::Configuration) -> void
   def self.configure: () { (CLI::Configuration) -> void } -> void
 
-  class CLI
-    attr_reader config_file: String?
+  class CLI < Thor
+    def all: () -> void
 
-    # @rbs argv: Array[String]
-    def run: (Array[String] argv) -> Integer
+    def models: () -> void
+
+    def path_helpers: () -> void
+
+    def version: () -> void
+
+    def self.exit_on_failure?: () -> bool
 
     private
 
-    def config: () -> Configuration
+    def apply_options: () -> void
+
+    def rbs_config: () -> Configuration
 
     def load_config: () -> void
 
@@ -29,7 +36,5 @@ module RbsRails
     def generate_single_model: (singleton(ActiveRecord::Base) klass) -> bool
 
     def generate_path_helpers: () -> void
-
-    def create_option_parser: () -> OptionParser
   end
 end

--- a/sig/rbs_rails/cli/configuration.rbs
+++ b/sig/rbs_rails/cli/configuration.rbs
@@ -1,7 +1,7 @@
 # Generated from lib/rbs_rails/cli/configuration.rb with RBS::Inline
 
 module RbsRails
-  class CLI
+  class CLI < Thor
     class Configuration
       include Singleton
 


### PR DESCRIPTION
Thor is declared as a runtime dependency in the gemspec, but since railties already depends on Thor, this adds no new dependency for users of rbs_rails (which always runs alongside Rails).