### PR TITLE
Fix #384: Quote enum methods whose names aren't bare RBS identifiers

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -425,7 +425,7 @@ module RbsRails
         klass.enum_definitions.each do |_, enum_method_name|
           ["#{enum_method_name}!", "#{enum_method_name}?"].each do |method_name|
             if defined_methods.member?(method_name.to_sym)
-              methods << "def #{method_name}: () -> bool"
+              methods << "def #{format_method_name(method_name)}: () -> bool"
             end
           end
         end
@@ -443,17 +443,29 @@ module RbsRails
           class_name = sql_type_to_class(column.type)
           method_name = "#{name.to_s.pluralize}"
           if defined_methods.member?(method_name.to_sym)
-            methods << "def #{singleton ? 'self.' : ''}#{method_name}: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, #{class_name}]"
+            methods << "def #{singleton ? 'self.' : ''}#{format_method_name(method_name)}: () -> ::ActiveSupport::HashWithIndifferentAccess[::String, #{class_name}]"
           end
         end
         klass.enum_definitions.each do |_, enum_method_name|
           ["#{enum_method_name}", "not_#{enum_method_name}"].each do |method_name|
             if defined_methods.member?(method_name.to_sym)
-              methods << "def #{singleton ? 'self.' : ''}#{method_name}: () -> #{relation_class_name}"
+              methods << "def #{singleton ? 'self.' : ''}#{format_method_name(method_name)}: () -> #{relation_class_name}"
             end
           end
         end
         methods.join("\n")
+      end
+
+      # Formats a method name for use in an RBS signature. ASCII-only
+      # Ruby identifiers are emitted as-is; everything else is wrapped in
+      # backticks, matching the behavior of RBS::Writer#method_name.
+      # @rbs method_name: String
+      private def format_method_name(method_name) #: String
+        if method_name.match?(/\A[A-Za-z_][A-Za-z0-9_]*[!?=]?\z/)
+          method_name
+        else
+          "`#{method_name}`"
+        end
       end
 
       # @rbs singleton: untyped

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
-  enum :status, [:temporary, :accepted], default: :temporary
+  enum :status, [:temporary, :accepted, :"123ABC", :"América"], default: :temporary
   enum :alias_role, [:member, :manager], default: :member
   enum :label, [:gold, :silver], default: :gold, scopes: false, instance_methods: false
 end

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -664,6 +664,10 @@ class ::User < ::ApplicationRecord
   def temporary?: () -> bool
   def accepted!: () -> bool
   def accepted?: () -> bool
+  def `123ABC!`: () -> bool
+  def `123ABC?`: () -> bool
+  def `América!`: () -> bool
+  def `América?`: () -> bool
   def member!: () -> bool
   def member?: () -> bool
   def manager!: () -> bool
@@ -675,6 +679,10 @@ class ::User < ::ApplicationRecord
   def self.not_temporary: () -> ::User::ActiveRecord_Relation
   def self.accepted: () -> ::User::ActiveRecord_Relation
   def self.not_accepted: () -> ::User::ActiveRecord_Relation
+  def self.`123ABC`: () -> ::User::ActiveRecord_Relation
+  def self.not_123ABC: () -> ::User::ActiveRecord_Relation
+  def self.`América`: () -> ::User::ActiveRecord_Relation
+  def self.`not_América`: () -> ::User::ActiveRecord_Relation
   def self.member: () -> ::User::ActiveRecord_Relation
   def self.not_member: () -> ::User::ActiveRecord_Relation
   def self.manager: () -> ::User::ActiveRecord_Relation
@@ -697,6 +705,14 @@ class ::User < ::ApplicationRecord
     def accepted: () -> ::User::ActiveRecord_Relation
 
     def not_accepted: () -> ::User::ActiveRecord_Relation
+
+    def `123ABC`: () -> ::User::ActiveRecord_Relation
+
+    def not_123ABC: () -> ::User::ActiveRecord_Relation
+
+    def `América`: () -> ::User::ActiveRecord_Relation
+
+    def `not_América`: () -> ::User::ActiveRecord_Relation
 
     def member: () -> ::User::ActiveRecord_Relation
 


### PR DESCRIPTION
When an ActiveRecord enum is defined with labels that aren't valid bare RBS identifiers (e.g. starting with a digit or containing multi-byte characters such as `123ABC` or `América`), the generated RBS file failed to parse with errors like:

    Error generating RBS for MyRailsModel model
    Error: a.rbs:281:4...281:7: Syntax error: unexpected token for method name, token=`123` (tINTEGER)

Wrap such method names in backticks, matching the convention used by RBS::Writer#method_name. ASCII-only Ruby identifiers continue to be emitted bare.

Close #384