### PR TITLE
Generate RBS signature for regenerate_* methods from has_secure_token

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -50,6 +50,7 @@ module RbsRails
           #{composed_of_aggregations}
           #{generated_association_methods}
           #{has_secure_password}
+          #{has_secure_token}
           #{delegated_type_instance}
           #{delegated_type_scope(singleton: true)}
           #{enum_instance_methods}
@@ -415,6 +416,27 @@ module RbsRails
             end
             include #{klass_name}::ActiveModel_SecurePassword_InstanceMethodsOnActivation_#{attribute}
           EOS
+        end.compact.join("\n")
+      end
+
+      private def has_secure_token #: String?
+        ast = parse_model_file
+        return unless ast
+
+        traverse(ast).map do |node|
+          # @type block: String?
+          next unless node.type == :send
+          next unless node.children[0].nil?
+          next unless node.children[1] == :has_secure_token
+
+          attribute_node = node.children[2]
+          attribute = if attribute_node && attribute_node.type == :sym
+                        attribute_node.children[0]
+                      else
+                        :token
+                      end
+
+          "def regenerate_#{attribute}: () -> true"
         end.compact.join("\n")
       end
 

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -66,6 +66,8 @@ module RbsRails
 
       private def has_secure_password: () -> String?
 
+      private def has_secure_token: () -> String?
+
       private def enum_instance_methods: () -> String
 
       # @rbs singleton: untyped

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_and_belongs_to_many :blogs
   has_many :delivery_addresses
   has_secure_password
+  has_secure_token
 
   serialize :phone_numbers, type: Array
   serialize :contact_info, type: Hash

--- a/test/app/db/migrate/20260510000001_add_token_to_users.rb
+++ b/test/app/db/migrate/20260510000001_add_token_to_users.rb
@@ -1,0 +1,6 @@
+class AddTokenToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :token, :string
+    add_index :users, :token, unique: true
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_10_140743) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_10_000001) do
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -121,7 +121,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_10_140743) do
     t.datetime "updated_at", null: false
     t.integer "role", null: false
     t.integer "label", null: false
+    t.string "token"
     t.index ["group_id"], name: "index_users_on_group_id"
+    t.index ["token"], name: "index_users_on_token", unique: true
   end
 
   add_foreign_key "delivery_addresses", "users"

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -483,6 +483,46 @@ class ::User < ::ApplicationRecord
     def label_before_type_cast: () -> ::Integer
 
     def label_for_database: () -> ::Integer
+
+    def token: () -> ::String?
+
+    def token=: (::String?) -> ::String?
+
+    def token?: () -> bool
+
+    def token_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def token_change: () -> [ ::String?, ::String? ]
+
+    def token_will_change!: () -> void
+
+    def token_was: () -> ::String?
+
+    def token_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def token_previous_change: () -> ::Array[::String?]?
+
+    def token_previously_was: () -> ::String?
+
+    def token_before_last_save: () -> ::String?
+
+    def token_change_to_be_saved: () -> ::Array[::String?]?
+
+    def token_in_database: () -> ::String?
+
+    def saved_change_to_token: () -> ::Array[::String?]?
+
+    def saved_change_to_token?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_token?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_token!: () -> void
+
+    def clear_token_change: () -> void
+
+    def token_before_type_cast: () -> ::String?
+
+    def token_for_database: () -> ::String?
   end
   include ::User::GeneratedAttributeMethods
   module ::User::GeneratedAliasAttributeMethods
@@ -659,6 +699,8 @@ class ::User < ::ApplicationRecord
     alias authenticate authenticate_password
   end
   include ::User::ActiveModel_SecurePassword_InstanceMethodsOnActivation_password
+
+  def regenerate_token: () -> true
 
   def temporary!: () -> bool
   def temporary?: () -> bool


### PR DESCRIPTION
## Summary

- `has_secure_token` calls now generate `def regenerate_<attribute>: () -> true` in the model's RBS output
- Follows the same AST-parsing pattern used by `has_secure_password`
- Return type is the literal `true` (not `bool`) because `update!` either returns `true` or raises — it never returns `false`
- Multiple `has_secure_token` calls on the same model are handled correctly (one `regenerate_*` per call)