### PR TITLE
Generate RBS type definitions for store / store_accessor accessors

### DIFF
--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -639,9 +639,38 @@ module RbsRails
           sig << "\n"
           sig
         end.join("\n")
+        mod_sig << store_accessor_methods
         mod_sig << "\nend\n"
         mod_sig << "include #{klass_name}::GeneratedAttributeMethods"
         mod_sig
+      end
+
+      private def store_accessor_methods #: String
+        klass.stored_attributes.each_value.flat_map do |accessors|
+          accessors.map do |accessor|
+            sig = <<~EOS
+              def #{accessor}: () -> ::String?
+              def #{accessor}=: (::String?) -> ::String?
+              def #{accessor}?: () -> bool
+              def #{accessor}_changed?: (?from: ::String?, ?to: ::String?) -> bool
+              def #{accessor}_change: () -> [::String?, ::String?]
+              def #{accessor}_will_change!: () -> void
+              def #{accessor}_was: () -> ::String?
+              def #{accessor}_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+              def #{accessor}_previous_change: () -> ::Array[::String?]?
+              def #{accessor}_previously_was: () -> ::String?
+              def #{accessor}_before_last_save: () -> ::String?
+              def #{accessor}_change_to_be_saved: () -> ::Array[::String?]?
+              def saved_change_to_#{accessor}: () -> ::Array[::String?]?
+              def saved_change_to_#{accessor}?: (?from: ::String?, ?to: ::String?) -> bool
+              def will_save_change_to_#{accessor}?: (?from: ::String?, ?to: ::String?) -> bool
+              def restore_#{accessor}!: () -> void
+              def clear_#{accessor}_change: () -> void
+            EOS
+            sig << "\n"
+            sig
+          end
+        end.join("\n")
       end
 
       private def alias_columns

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -14,6 +14,9 @@ class User < ApplicationRecord
   serialize :contact_info, type: Hash
   serialize :family_tree, coder: JSON
 
+  store :preferences, accessors: [:theme, :notifications_enabled]
+  store_accessor :preferences, :language
+
   has_one_attached :avatar
 
   enum :status, [:temporary, :accepted], default: :temporary

--- a/test/app/db/migrate/20260509115844_add_preferences_to_users.rb
+++ b/test/app/db/migrate/20260509115844_add_preferences_to_users.rb
@@ -1,0 +1,5 @@
+class AddPreferencesToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :preferences, :text
+  end
+end

--- a/test/app/db/schema.rb
+++ b/test/app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_10_140743) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_09_115844) do
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id"
     t.string "auditable_type"
@@ -121,6 +121,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_10_140743) do
     t.datetime "updated_at", null: false
     t.integer "role", null: false
     t.integer "label", null: false
+    t.text "preferences"
     t.index ["group_id"], name: "index_users_on_group_id"
   end
 

--- a/test/expectations/user.rbs
+++ b/test/expectations/user.rbs
@@ -483,6 +483,148 @@ class ::User < ::ApplicationRecord
     def label_before_type_cast: () -> ::Integer
 
     def label_for_database: () -> ::Integer
+
+    def preferences: () -> ::String?
+
+    def preferences=: (::String?) -> ::String?
+
+    def preferences?: () -> bool
+
+    def preferences_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def preferences_change: () -> [ ::String?, ::String? ]
+
+    def preferences_will_change!: () -> void
+
+    def preferences_was: () -> ::String?
+
+    def preferences_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def preferences_previous_change: () -> ::Array[::String?]?
+
+    def preferences_previously_was: () -> ::String?
+
+    def preferences_before_last_save: () -> ::String?
+
+    def preferences_change_to_be_saved: () -> ::Array[::String?]?
+
+    def preferences_in_database: () -> ::String?
+
+    def saved_change_to_preferences: () -> ::Array[::String?]?
+
+    def saved_change_to_preferences?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_preferences?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_preferences!: () -> void
+
+    def clear_preferences_change: () -> void
+
+    def preferences_before_type_cast: () -> ::String?
+
+    def preferences_for_database: () -> ::String?
+
+    def theme: () -> ::String?
+
+    def theme=: (::String?) -> ::String?
+
+    def theme?: () -> bool
+
+    def theme_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def theme_change: () -> [ ::String?, ::String? ]
+
+    def theme_will_change!: () -> void
+
+    def theme_was: () -> ::String?
+
+    def theme_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def theme_previous_change: () -> ::Array[::String?]?
+
+    def theme_previously_was: () -> ::String?
+
+    def theme_before_last_save: () -> ::String?
+
+    def theme_change_to_be_saved: () -> ::Array[::String?]?
+
+    def saved_change_to_theme: () -> ::Array[::String?]?
+
+    def saved_change_to_theme?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_theme?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_theme!: () -> void
+
+    def clear_theme_change: () -> void
+
+    def notifications_enabled: () -> ::String?
+
+    def notifications_enabled=: (::String?) -> ::String?
+
+    def notifications_enabled?: () -> bool
+
+    def notifications_enabled_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def notifications_enabled_change: () -> [ ::String?, ::String? ]
+
+    def notifications_enabled_will_change!: () -> void
+
+    def notifications_enabled_was: () -> ::String?
+
+    def notifications_enabled_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def notifications_enabled_previous_change: () -> ::Array[::String?]?
+
+    def notifications_enabled_previously_was: () -> ::String?
+
+    def notifications_enabled_before_last_save: () -> ::String?
+
+    def notifications_enabled_change_to_be_saved: () -> ::Array[::String?]?
+
+    def saved_change_to_notifications_enabled: () -> ::Array[::String?]?
+
+    def saved_change_to_notifications_enabled?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_notifications_enabled?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_notifications_enabled!: () -> void
+
+    def clear_notifications_enabled_change: () -> void
+
+    def language: () -> ::String?
+
+    def language=: (::String?) -> ::String?
+
+    def language?: () -> bool
+
+    def language_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def language_change: () -> [ ::String?, ::String? ]
+
+    def language_will_change!: () -> void
+
+    def language_was: () -> ::String?
+
+    def language_previously_changed?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def language_previous_change: () -> ::Array[::String?]?
+
+    def language_previously_was: () -> ::String?
+
+    def language_before_last_save: () -> ::String?
+
+    def language_change_to_be_saved: () -> ::Array[::String?]?
+
+    def saved_change_to_language: () -> ::Array[::String?]?
+
+    def saved_change_to_language?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def will_save_change_to_language?: (?from: ::String?, ?to: ::String?) -> bool
+
+    def restore_language!: () -> void
+
+    def clear_language_change: () -> void
   end
   include ::User::GeneratedAttributeMethods
   module ::User::GeneratedAliasAttributeMethods


### PR DESCRIPTION
## Summary

- Fix missing RBS type definitions for attributes defined via `store` / `store_accessor`
- Use `klass.stored_attributes` to detect registered accessors and generate `::String?`-typed methods inside `GeneratedAttributeMethods`
- Generate getter, setter, and dirty tracking methods (`_changed?`, `_was`, `_previously_changed?`, etc.) — excluding `_in_database`, `_before_type_cast`, and `_for_database` which are not defined for virtual store accessors
- Extract generation logic into a dedicated `store_accessor_methods` private method