### PR TITLE
ci: use latest bundler to fix ruby-head build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler: 'latest'
     - run: bin/setup
     - run: bundle exec rake


### PR DESCRIPTION
## Summary

Ruby HEAD (4.1.0+1) changed `Pathname::SEPARATOR_PAT` from a public to a private constant.
Bundler 2.4.13 (shipped with ruby-head) references this constant in
`lib/bundler/source/path.rb#generate_bin`, causing a `NameError` and breaking CI.

This PR adds `bundler: 'latest'` to the `ruby/setup-ruby` action so that a newer Bundler
(which does not reference `Pathname::SEPARATOR_PAT`) is installed instead of the one
bundled with the Ruby distribution.

## Error

[NameError: private constant Pathname::SEPARATOR_PAT referenced
bundler-2.4.13/lib/bundler/source/path.rb:228:in 'Bundler::Source::Path#generate_bin'](https://github.com/pocke/rbs_rails/actions/runs/25600715014/job/75153993551)
