### PR TITLE
ci: fix ruby-head build failure due to Pathname::SEPARATOR_PAT being made private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler: 'latest'
     - run: bin/setup
     - run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,4 +251,4 @@ DEPENDENCIES
   tsort
 
 BUNDLED WITH
-   2.4.13
+  4.0.11


### PR DESCRIPTION
## Problem

The CI build for `ruby-head` was failing with:

NameError: private constant Pathname::SEPARATOR_PAT referenced

Ruby HEAD (4.1.0dev) made `Pathname::SEPARATOR_PAT` private. All released
Bundler versions (including 2.4.13, 2.6.6, and 4.0.x) reference this constant
in `Bundler::Source::Path#generate_bin`. However, Ruby HEAD ships Bundler
4.1.0.dev as a built-in gem that contains the fix.

[ref](https://github.com/pocke/rbs_rails/actions/runs/25600715014/job/75153993551)

## Root cause of first fix attempt failing

Adding `bundler: 'latest'` alone was insufficient. Here is what happened:

1. `ruby/setup-ruby` with `bundler: 'latest'` sets `BUNDLER_VERSION=4` (major only, not pinned)
2. On Ruby HEAD, the highest available 4.x bundler is 4.1.0.dev (built-in)
3. Bundler 4.1.0.dev reads `BUNDLED WITH 2.4.13` in Gemfile.lock and auto-downgrades
   because of a major version mismatch (4 vs 2)
4. Bundler 2.4.13 is installed into `vendor/bundle`, the process restarts, and fails
   again with the same `NameError`