### PR TITLE
Fix ActiveRecord association RBS generation when an association target is ignored or cannot be generated.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,4 +251,4 @@ DEPENDENCIES
   tsort
 
 BUNDLED WITH
-   2.4.13
+   4.0.15

--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -167,63 +167,25 @@ module RbsRails
       end
 
       private def has_many #: String
-        klass.reflect_on_all_associations(:has_many).map do |a|
-          @dependencies << a.klass.name
-
-          singular_name = a.name.to_s.singularize
-          type = Util.module_name(a.klass)
-          collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
-          @dependencies << collection_type
-          association_pk_type = pk_type_for(a.klass)
-
-          <<~RUBY.chomp
-            def #{a.name}: () -> #{collection_type}
-            def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
-            def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
-            def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
-          RUBY
+        associations_for(:has_many, require_generatable: true).map do |a|
+          collection_association_signature(a)
         end.join("\n")
       end
 
       private def has_and_belongs_to_many #: String
-        klass.reflect_on_all_associations(:has_and_belongs_to_many).map do |a|
-          @dependencies << a.klass.name
-
-          singular_name = a.name.to_s.singularize
-          type = Util.module_name(a.klass)
-          collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
-          @dependencies << collection_type
-          association_pk_type = pk_type_for(a.klass)
-
-          <<~RUBY.chomp
-            def #{a.name}: () -> #{collection_type}
-            def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
-            def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
-            def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
-          RUBY
+        associations_for(:has_and_belongs_to_many, require_generatable: true).map do |a|
+          collection_association_signature(a)
         end.join("\n")
       end
 
       private def has_one #: String
-        klass.reflect_on_all_associations(:has_one).map do |a|
-          @dependencies << a.klass.name unless a.polymorphic?
-
-          type = a.polymorphic? ? 'untyped' : Util.module_name(a.klass)
-          type_optional = optional(type)
-          <<~RUBY.chomp
-            def #{a.name}: () -> #{type_optional}
-            def #{a.name}=: (#{type_optional}) -> #{type_optional}
-            def build_#{a.name}: (?untyped) -> #{type}
-            def create_#{a.name}: (?untyped) -> #{type}
-            def create_#{a.name}!: (?untyped) -> #{type}
-            def reload_#{a.name}: () -> #{type_optional}
-            def reset_#{a.name}: () -> void
-          RUBY
+        associations_for(:has_one).map do |a|
+          singular_association_signature(a, builder_methods: true)
         end.join("\n")
       end
 
       private def belongs_to #: String
-        klass.reflect_on_all_associations(:belongs_to).map do |a|
+        associations_for(:belongs_to).map do |a|
           @dependencies << a.klass.name unless a.polymorphic?
 
           is_optional = a.options[:optional]
@@ -245,6 +207,64 @@ module RbsRails
           end
           methods.join("\n")
         end.join("\n")
+      end
+
+      # @rbs require_generatable: boolish
+      private def associations_for(macro, require_generatable: false) #: untyped
+        klass.reflect_on_all_associations(macro).select do |association|
+          generatable_association?(association, require_generatable:)
+        end
+      end
+
+      # @rbs require_generatable: boolish
+      private def generatable_association?(association, require_generatable:) #: boolish
+        return true if association.polymorphic?
+
+        association_klass = association.klass
+        return false if CLI::Configuration.instance.ignored_model?(association_klass)
+        return true unless require_generatable
+
+        ActiveRecord.generatable?(association_klass)
+      rescue ::ActiveRecord::StatementInvalid
+        false
+      end
+
+      private def collection_association_signature(a) #: String
+        @dependencies << a.klass.name
+
+        singular_name = a.name.to_s.singularize
+        type = Util.module_name(a.klass)
+        collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
+        @dependencies << collection_type
+        association_pk_type = pk_type_for(a.klass)
+
+        <<~RUBY.chomp
+          def #{a.name}: () -> #{collection_type}
+          def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
+          def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
+          def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
+        RUBY
+      end
+
+      # @rbs builder_methods: boolish
+      # @rbs optional_reader: boolish
+      private def singular_association_signature(a, builder_methods:, optional_reader: true) #: String
+        @dependencies << a.klass.name unless a.polymorphic?
+
+        type = a.polymorphic? ? 'untyped' : Util.module_name(a.klass)
+        type_optional = optional(type)
+        # @type var methods: Array[String]
+        methods = []
+        methods << "def #{a.name}: () -> #{optional_reader ? type_optional : type}"
+        methods << "def #{a.name}=: (#{type_optional}) -> #{type_optional}"
+        if builder_methods
+          methods << "def build_#{a.name}: (?untyped) -> #{type}"
+          methods << "def create_#{a.name}: (?untyped) -> #{type}"
+          methods << "def create_#{a.name}!: (?untyped) -> #{type}"
+        end
+        methods << "def reload_#{a.name}: () -> #{type_optional}"
+        methods << "def reset_#{a.name}: () -> void"
+        methods.join("\n")
       end
 
       private def composed_of_aggregations #: String

--- a/lib/rbs_rails/active_record.rb
+++ b/lib/rbs_rails/active_record.rb
@@ -168,19 +168,57 @@ module RbsRails
 
       private def has_many #: String
         associations_for(:has_many, require_generatable: true).map do |a|
-          collection_association_signature(a)
+          @dependencies << a.klass.name
+
+          singular_name = a.name.to_s.singularize
+          type = Util.module_name(a.klass)
+          collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
+          @dependencies << collection_type
+          association_pk_type = pk_type_for(a.klass)
+
+          <<~RUBY.chomp
+            def #{a.name}: () -> #{collection_type}
+            def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
+            def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
+            def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
+          RUBY
         end.join("\n")
       end
 
       private def has_and_belongs_to_many #: String
         associations_for(:has_and_belongs_to_many, require_generatable: true).map do |a|
-          collection_association_signature(a)
+          @dependencies << a.klass.name
+
+          singular_name = a.name.to_s.singularize
+          type = Util.module_name(a.klass)
+          collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
+          @dependencies << collection_type
+          association_pk_type = pk_type_for(a.klass)
+
+          <<~RUBY.chomp
+            def #{a.name}: () -> #{collection_type}
+            def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
+            def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
+            def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
+          RUBY
         end.join("\n")
       end
 
       private def has_one #: String
         associations_for(:has_one).map do |a|
-          singular_association_signature(a, builder_methods: true)
+          @dependencies << a.klass.name unless a.polymorphic?
+
+          type = a.polymorphic? ? 'untyped' : Util.module_name(a.klass)
+          type_optional = optional(type)
+          <<~RUBY.chomp
+            def #{a.name}: () -> #{type_optional}
+            def #{a.name}=: (#{type_optional}) -> #{type_optional}
+            def build_#{a.name}: (?untyped) -> #{type}
+            def create_#{a.name}: (?untyped) -> #{type}
+            def create_#{a.name}!: (?untyped) -> #{type}
+            def reload_#{a.name}: () -> #{type_optional}
+            def reset_#{a.name}: () -> void
+          RUBY
         end.join("\n")
       end
 
@@ -210,12 +248,13 @@ module RbsRails
       end
 
       # @rbs require_generatable: boolish
-      private def associations_for(macro, require_generatable: false) #: untyped
+      private def associations_for(macro, require_generatable: false) #: Array[::ActiveRecord::Reflection::AssociationReflection]
         klass.reflect_on_all_associations(macro).select do |association|
           generatable_association?(association, require_generatable:)
         end
       end
 
+      # @rbs association: ::ActiveRecord::Reflection::AssociationReflection
       # @rbs require_generatable: boolish
       private def generatable_association?(association, require_generatable:) #: boolish
         return true if association.polymorphic?
@@ -227,44 +266,6 @@ module RbsRails
         ActiveRecord.generatable?(association_klass)
       rescue ::ActiveRecord::StatementInvalid
         false
-      end
-
-      private def collection_association_signature(a) #: String
-        @dependencies << a.klass.name
-
-        singular_name = a.name.to_s.singularize
-        type = Util.module_name(a.klass)
-        collection_type = "#{type}::ActiveRecord_Associations_CollectionProxy"
-        @dependencies << collection_type
-        association_pk_type = pk_type_for(a.klass)
-
-        <<~RUBY.chomp
-          def #{a.name}: () -> #{collection_type}
-          def #{a.name}=: (#{collection_type} | ::Array[#{type}]) -> (#{collection_type} | ::Array[#{type}])
-          def #{singular_name}_ids: () -> ::Array[#{association_pk_type}]
-          def #{singular_name}_ids=: (::Array[#{association_pk_type}]) -> ::Array[#{association_pk_type}]
-        RUBY
-      end
-
-      # @rbs builder_methods: boolish
-      # @rbs optional_reader: boolish
-      private def singular_association_signature(a, builder_methods:, optional_reader: true) #: String
-        @dependencies << a.klass.name unless a.polymorphic?
-
-        type = a.polymorphic? ? 'untyped' : Util.module_name(a.klass)
-        type_optional = optional(type)
-        # @type var methods: Array[String]
-        methods = []
-        methods << "def #{a.name}: () -> #{optional_reader ? type_optional : type}"
-        methods << "def #{a.name}=: (#{type_optional}) -> #{type_optional}"
-        if builder_methods
-          methods << "def build_#{a.name}: (?untyped) -> #{type}"
-          methods << "def create_#{a.name}: (?untyped) -> #{type}"
-          methods << "def create_#{a.name}!: (?untyped) -> #{type}"
-        end
-        methods << "def reload_#{a.name}: () -> #{type_optional}"
-        methods << "def reset_#{a.name}: () -> void"
-        methods.join("\n")
       end
 
       private def composed_of_aggregations #: String

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -52,16 +52,11 @@ module RbsRails
       private def belongs_to: () -> String
 
       # @rbs require_generatable: boolish
-      private def associations_for: (untyped macro, ?require_generatable: boolish) -> untyped
+      private def associations_for: (untyped macro, ?require_generatable: boolish) -> Array[::ActiveRecord::Reflection::AssociationReflection]
 
+      # @rbs association: ::ActiveRecord::Reflection::AssociationReflection
       # @rbs require_generatable: boolish
-      private def generatable_association?: (untyped association, require_generatable: boolish) -> boolish
-
-      private def collection_association_signature: (untyped a) -> String
-
-      # @rbs builder_methods: boolish
-      # @rbs optional_reader: boolish
-      private def singular_association_signature: (untyped a, builder_methods: boolish, ?optional_reader: boolish) -> String
+      private def generatable_association?: (::ActiveRecord::Reflection::AssociationReflection association, require_generatable: boolish) -> boolish
 
       private def composed_of_aggregations: () -> String
 

--- a/sig/rbs_rails/active_record.rbs
+++ b/sig/rbs_rails/active_record.rbs
@@ -51,6 +51,18 @@ module RbsRails
 
       private def belongs_to: () -> String
 
+      # @rbs require_generatable: boolish
+      private def associations_for: (untyped macro, ?require_generatable: boolish) -> untyped
+
+      # @rbs require_generatable: boolish
+      private def generatable_association?: (untyped association, require_generatable: boolish) -> boolish
+
+      private def collection_association_signature: (untyped a) -> String
+
+      # @rbs builder_methods: boolish
+      # @rbs optional_reader: boolish
+      private def singular_association_signature: (untyped a, builder_methods: boolish, ?optional_reader: boolish) -> String
+
       private def composed_of_aggregations: () -> String
 
       private def nested_attributes_methods: () -> String?
@@ -70,6 +82,12 @@ module RbsRails
 
       # @rbs singleton: untyped
       private def enum_class_methods: (singleton: untyped) -> String
+
+      # Formats a method name for use in an RBS signature. ASCII-only
+      # Ruby identifiers are emitted as-is; everything else is wrapped in
+      # backticks, matching the behavior of RBS::Writer#method_name.
+      # @rbs method_name: String
+      private def format_method_name: (String method_name) -> String
 
       # @rbs singleton: untyped
       private def scopes: (singleton: untyped) -> untyped

--- a/test/app/Gemfile.lock
+++ b/test/app/Gemfile.lock
@@ -288,4 +288,4 @@ DEPENDENCIES
   tsort
 
 BUNDLED WITH
-   2.4.13
+   4.0.15

--- a/test/app/app/models/user.rb
+++ b/test/app/app/models/user.rb
@@ -8,6 +8,10 @@ class User < ApplicationRecord
   belongs_to :group
   has_and_belongs_to_many :blogs
   has_many :delivery_addresses
+  belongs_to :featured_article, class_name: "Article", optional: true
+  has_and_belongs_to_many :related_articles, class_name: "Article"
+  has_many :articles
+  has_one :latest_article, class_name: "Article"
   has_secure_password
 
   serialize :phone_numbers, type: Array

--- a/test/app/config/rbs_rails.rb
+++ b/test/app/config/rbs_rails.rb
@@ -1,6 +1,6 @@
 RbsRails.configure do |config|
   config.ignore_model_if do |klass|
     # klass.name == "User"
-    false
+    klass.name == "Article"
   end
 end

--- a/test/pg_app/Gemfile.lock
+++ b/test/pg_app/Gemfile.lock
@@ -284,4 +284,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.4.13
+   4.0.15


### PR DESCRIPTION
Previously, `ignore_model_if` prevented direct RBS generation for a model, but association generation could still resolve that model through `reflection.klass`. For collection associations, rbs_rails then inspected the target model columns to infer ID types, which could raise when the ignored association target had no backing table.

One real-world example is `ActiveStorage::VariantRecord`. In apps with ActiveStorage variants disabled(see https://guides.rubyonrails.org/configuring.html#config-active-storage-track-variants) or without the `active_storage_variant_records` table, generation can fail while generating `ActiveStorage::Blob`:

  ```text
  Error generating RBS for ActiveStorage::Blob model
  Error: PG::UndefinedTable: ERROR:  relation "active_storage_variant_records" does not exist
  LINE 10:  WHERE a.attrelid = '"active_storage_variant_records"'::regc...
                               ^
  rake aborted!
  Command failed with status (1): [rbs_rails all]
  Tasks: TOP => rbs_rails:all
```

Ignoring ActiveStorage::VariantRecord alone is not enough, because ActiveStorage::Blob#variant_records can still be introspected during association generation.

  ## Changes

  - Route ActiveRecord association generation through a shared association filter.
  - Add regression coverage in the test app with ignored Article associations for all association macros.
