### PR TITLE
Pin GitHub Actions to commit SHAs and update to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         ruby: ['3.2', '3.3', '3.4', '4.0', head]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
         ruby: ['3.2', '3.3', '3.4', '4.0', head]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install PostgreSQL client libraries
         run: sudo apt-get install -y libpq-dev
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0

--- a/.github/workflows/postgresql.yml
+++ b/.github/workflows/postgresql.yml
@@ -28,10 +28,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install PostgreSQL client libraries
         run: sudo apt-get install -y libpq-dev
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '4.0'
           bundler-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
           bundler-cache: true
 
       - name: Publish to RubyGems
-        uses: rubygems/release-gem@v1
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0


### PR DESCRIPTION
## Summary

Harden the CI supply chain by pinning every third-party GitHub Action to a full commit SHA (with a version comment), and bump them to their latest releases. Both steps were done with [pinact](https://github.com/suzuki-shunsuke/pinact).

This is split into two commits:

1. **Pin to commit SHAs** (`pinact run`) — pinning to an immutable SHA prevents a tag from being silently re-pointed at malicious code, the recommended supply-chain hardening practice for GitHub Actions.
2. **Update to latest** (`pinact run --update`) — only `actions/checkout` had a newer release; `ruby/setup-ruby` and `rubygems/release-gem` were already current.

## Changes

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` (ci.yml) | `@v2` | `@9c091bb…` # v7.0.0 |
| `actions/checkout` (postgresql.yml, release.yml) | `@v4` | `@9c091bb…` # v7.0.0 |
| `ruby/setup-ruby` | `@v1` | `@9eb537ca…` # v1.314.0 |
| `rubygems/release-gem` | `@v1` | `@052cc82…` # v1.4.0 |

This also resolves a pre-existing inconsistency where `ci.yml` was still on `checkout@v2` (Node 12 based, deprecated) while the other workflows were on v4. All three workflows now share v7.0.0.

## Compatibility notes

`actions/checkout` is a major upgrade (v2/v4 → v7), so I checked the breaking changes against how these workflows use it:

- **v7's "block checking out fork PR for `pull_request_target` / `workflow_run`"** does not apply: the workflows only use `push` and the standard `pull_request` trigger, so fork PRs continue to run normally.
- **Node 24 runtime requirement (v5/v6)**: all jobs run on `ubuntu-latest` (GitHub-hosted), which always satisfies this.
- The checkout is a plain, argument-less checkout (no submodules, sparse-checkout, or special `ref`), so default-behavior changes between versions don't affect us.

## Follow-up

`release.yml` pushes a git tag via `rubygems/release-gem`, relying on the credentials persisted by `checkout`. The default `persist-credentials: true` is unchanged in v7, but this path can't be exercised in CI — worth a one-time visual check on the next release that the tag push still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
